### PR TITLE
[UI][#26-1] Navigation基盤の最小導入

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/issy/meshigen/navigation/MeshigenDestination.kt
+++ b/app/src/main/java/com/issy/meshigen/navigation/MeshigenDestination.kt
@@ -1,0 +1,12 @@
+package com.issy.meshigen.navigation
+
+object MeshigenDestination {
+    const val HOME_ROUTE = "home"
+    const val COLLECTION_ROUTE = "collection"
+    const val GOURMET_ID_ARG = "gourmetId"
+    const val DETAIL_ROUTE = "detail/{$GOURMET_ID_ARG}"
+
+    fun createDetailRoute(gourmetId: String): String {
+        return "detail/$gourmetId"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
 kotlin = "2.0.21"
 composeBom = "2024.09.00"
+navigationCompose = "2.8.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,8 +25,8 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-


### PR DESCRIPTION
## 概要
Issue #27 の対応として、Navigation Compose の最小導入を行い、画面遷移ルートを `MeshigenDestination` に集約しました。

## 変更内容
- `gradle/libs.versions.toml` に `navigation-compose` を追加
- `app/build.gradle.kts` に `implementation(libs.androidx.navigation.compose)` を追加
- `MeshigenDestination.kt` を新規作成
- `home` / `collection` / `detail/{gourmetId}` のルート定義を追加
- `createDetailRoute(gourmetId)` を追加

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Issue #27 の実装タスク/DoDチェックリストを更新済み

## コミット
- `feat: Navigation Compose依存を追加`
- `feat: 遷移ルート定義を集約`

## 関連Issue
- Closes #27
- Refs #26
