### PR TITLE
[UI][#26-2] AppShell + BottomNavigationの最小実装

### DIFF
--- a/app/src/main/java/com/issy/meshigen/MainActivity.kt
+++ b/app/src/main/java/com/issy/meshigen/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import com.issy.meshigen.feature.home.HomeScreen
+import com.issy.meshigen.navigation.MeshigenAppShell
 import com.issy.meshigen.ui.theme.MeshigenTheme
 
 class MainActivity : ComponentActivity() {
@@ -13,7 +13,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             MeshigenTheme {
-                HomeScreen()
+                MeshigenAppShell()
             }
         }
     }

--- a/app/src/main/java/com/issy/meshigen/navigation/MeshigenAppShell.kt
+++ b/app/src/main/java/com/issy/meshigen/navigation/MeshigenAppShell.kt
@@ -1,0 +1,88 @@
+package com.issy.meshigen.navigation
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.issy.meshigen.R
+import com.issy.meshigen.ui.theme.MeshigenTheme
+
+private data class TopLevelDestination(
+    val route: String,
+    val labelResId: Int,
+    val icon: @Composable () -> Unit,
+)
+
+@Composable
+internal fun MeshigenAppShell(
+    modifier: Modifier = Modifier,
+) {
+    val navController = rememberNavController()
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = currentBackStackEntry?.destination?.route
+
+    val topLevelDestinations = listOf(
+        TopLevelDestination(
+            route = MeshigenDestination.HOME_ROUTE,
+            labelResId = R.string.navigation_home,
+            icon = { Icon(imageVector = Icons.Filled.Home, contentDescription = null) },
+        ),
+        TopLevelDestination(
+            route = MeshigenDestination.COLLECTION_ROUTE,
+            labelResId = R.string.navigation_collection,
+            icon = { Icon(imageVector = Icons.AutoMirrored.Filled.List, contentDescription = null) },
+        ),
+    )
+
+    Scaffold(
+        modifier = modifier,
+        bottomBar = {
+            NavigationBar {
+                topLevelDestinations.forEach { destination ->
+                    val isSelected = currentRoute == destination.route
+
+                    NavigationBarItem(
+                        selected = isSelected,
+                        onClick = {
+                            navController.navigate(destination.route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        icon = destination.icon,
+                        label = { Text(text = stringResource(destination.labelResId)) },
+                    )
+                }
+            }
+        },
+    ) { innerPadding ->
+        MeshigenNavHost(
+            navController = navController,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MeshigenAppShellPreview() {
+    MeshigenTheme {
+        MeshigenAppShell()
+    }
+}

--- a/app/src/main/java/com/issy/meshigen/navigation/MeshigenNavHost.kt
+++ b/app/src/main/java/com/issy/meshigen/navigation/MeshigenNavHost.kt
@@ -1,0 +1,28 @@
+package com.issy.meshigen.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.issy.meshigen.feature.collection.CollectionListScreen
+import com.issy.meshigen.feature.home.HomeScreen
+
+@Composable
+internal fun MeshigenNavHost(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+) {
+    NavHost(
+        navController = navController,
+        startDestination = MeshigenDestination.HOME_ROUTE,
+        modifier = modifier,
+    ) {
+        composable(route = MeshigenDestination.HOME_ROUTE) {
+            HomeScreen()
+        }
+        composable(route = MeshigenDestination.COLLECTION_ROUTE) {
+            CollectionListScreen()
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">Meshigen</string>
+    <string name="navigation_home">ホーム</string>
+    <string name="navigation_collection">図鑑</string>
 
     <string name="home_title">今の気分は？</string>
     <string name="home_description">今の気分を入力すると、おすすめの北九州市のB級グルメを提案します。</string>


### PR DESCRIPTION
## 概要
Issue #28 の対応として、共通 AppShell と BottomNavigation を追加し、Home/Collection タブ切替の最小構成を実装しました。

## 変更内容
- `navigation/MeshigenAppShell.kt` を新規作成
- `Scaffold(bottomBar=...)` + `NavigationBar` を実装
- BottomNavigation 押下で `home` / `collection` に遷移する設定を追加
- `navigation/MeshigenNavHost.kt` を新規作成し、`NavHost(startDestination=home)` に2ルートを登録
- `MainActivity` の表示起点を `MeshigenAppShell()` に変更
- `strings.xml` に BottomNavigation 用文言（ホーム/図鑑）を追加

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Home⇄Collection のタブ遷移を手動確認

## コミット
- `feat: AppShellとBottomNavigationを追加`

## 関連Issue
- Closes #28
- Refs #26
