### PR TITLE
[UI][#26-3] Detail遷移の最小接続（BottomBar非表示込み）

### DIFF
--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreen.kt
@@ -46,7 +46,9 @@ data class CollectionFilterUiModel(
 )
 
 @Composable
-internal fun CollectionListScreen() {
+internal fun CollectionListScreen(
+    onItemClick: (String) -> Unit,
+) {
     val filters = listOf(
         CollectionFilterUiModel(
             id = "all",
@@ -82,7 +84,7 @@ internal fun CollectionListScreen() {
         filters = filters,
         items = items,
         onFilterClick = {},
-        onItemClick = {},
+        onItemClick = { item -> onItemClick(item.id) },
         onFavoriteClick = {},
     )
 }

--- a/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreen.kt
@@ -42,15 +42,18 @@ data class DetailUiModel(
 )
 
 @Composable
-internal fun DetailScreen() {
-    val baseUiModel = remember {
+internal fun DetailScreen(
+    gourmetId: String,
+    onBackClick: () -> Unit,
+) {
+    val baseUiModel = remember(gourmetId) {
         DetailUiModel(
             name = "小倉焼うどん",
             category = "麺",
             area = "小倉北区",
             description = "小倉発祥の焼うどん。香ばしいソースの香りともちもち食感が魅力です。",
             aiComment = "今日はしっかり食べたい気分にぴったり。鉄板で香ばしく仕上がる満足感が高い一品です。",
-            moodText = "ガッツリ食べたい",
+            moodText = "ガッツリ食べたい（id: $gourmetId）",
             suggestedDate = "2026-04-07",
             favorite = false,
         )
@@ -59,7 +62,7 @@ internal fun DetailScreen() {
 
     DetailScreenContent(
         uiModel = baseUiModel.copy(favorite = favorite),
-        onBackClick = { },
+        onBackClick = onBackClick,
         onToggleFavoriteClick = { favorite = !favorite },
         onDeleteClick = { },
         onOpenMapClick = { },

--- a/app/src/main/java/com/issy/meshigen/navigation/MeshigenAppShell.kt
+++ b/app/src/main/java/com/issy/meshigen/navigation/MeshigenAppShell.kt
@@ -33,6 +33,7 @@ internal fun MeshigenAppShell(
     val navController = rememberNavController()
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = currentBackStackEntry?.destination?.route
+    val isDetailRoute = currentRoute?.startsWith(MeshigenDestination.DETAIL_BASE_ROUTE) == true
 
     val topLevelDestinations = listOf(
         TopLevelDestination(
@@ -50,24 +51,26 @@ internal fun MeshigenAppShell(
     Scaffold(
         modifier = modifier,
         bottomBar = {
-            NavigationBar {
-                topLevelDestinations.forEach { destination ->
-                    val isSelected = currentRoute == destination.route
+            if (!isDetailRoute) {
+                NavigationBar {
+                    topLevelDestinations.forEach { destination ->
+                        val isSelected = currentRoute == destination.route
 
-                    NavigationBarItem(
-                        selected = isSelected,
-                        onClick = {
-                            navController.navigate(destination.route) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+                        NavigationBarItem(
+                            selected = isSelected,
+                            onClick = {
+                                navController.navigate(destination.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                        icon = destination.icon,
-                        label = { Text(text = stringResource(destination.labelResId)) },
-                    )
+                            },
+                            icon = destination.icon,
+                            label = { Text(text = stringResource(destination.labelResId)) },
+                        )
+                    }
                 }
             }
         },

--- a/app/src/main/java/com/issy/meshigen/navigation/MeshigenDestination.kt
+++ b/app/src/main/java/com/issy/meshigen/navigation/MeshigenDestination.kt
@@ -3,10 +3,11 @@ package com.issy.meshigen.navigation
 object MeshigenDestination {
     const val HOME_ROUTE = "home"
     const val COLLECTION_ROUTE = "collection"
+    const val DETAIL_BASE_ROUTE = "detail"
     const val GOURMET_ID_ARG = "gourmetId"
-    const val DETAIL_ROUTE = "detail/{$GOURMET_ID_ARG}"
+    const val DETAIL_ROUTE = "$DETAIL_BASE_ROUTE/{$GOURMET_ID_ARG}"
 
     fun createDetailRoute(gourmetId: String): String {
-        return "detail/$gourmetId"
+        return "$DETAIL_BASE_ROUTE/$gourmetId"
     }
 }

--- a/app/src/main/java/com/issy/meshigen/navigation/MeshigenNavHost.kt
+++ b/app/src/main/java/com/issy/meshigen/navigation/MeshigenNavHost.kt
@@ -2,10 +2,13 @@ package com.issy.meshigen.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.issy.meshigen.feature.collection.CollectionListScreen
+import com.issy.meshigen.feature.detail.DetailScreen
 import com.issy.meshigen.feature.home.HomeScreen
 
 @Composable
@@ -22,7 +25,30 @@ internal fun MeshigenNavHost(
             HomeScreen()
         }
         composable(route = MeshigenDestination.COLLECTION_ROUTE) {
-            CollectionListScreen()
+            CollectionListScreen(
+                onItemClick = { gourmetId ->
+                    navController.navigate(
+                        MeshigenDestination.createDetailRoute(gourmetId)
+                    )
+                },
+            )
+        }
+        composable(
+            route = MeshigenDestination.DETAIL_ROUTE,
+            arguments = listOf(
+                navArgument(MeshigenDestination.GOURMET_ID_ARG) {
+                    type = NavType.StringType
+                }
+            ),
+        ) { backStackEntry ->
+            val gourmetId = backStackEntry.arguments
+                ?.getString(MeshigenDestination.GOURMET_ID_ARG)
+                .orEmpty()
+
+            DetailScreen(
+                gourmetId = gourmetId,
+                onBackClick = { navController.navigateUp() },
+            )
         }
     }
 }


### PR DESCRIPTION
## 概要
Issue #29 の対応として、一覧カードから詳細への引数付き遷移を接続し、詳細画面表示中は BottomNavigation を非表示にしました。

## 変更内容
- `CollectionListScreen` の `onItemClick` を NavHost 経由の遷移に接続
- `MeshigenNavHost` に `detail/{gourmetId}` ルートを追加し、引数を受けて `DetailScreen` に連携
- `MeshigenAppShell` で current route を判定し、詳細画面では BottomNavigation を非表示化
- Detail からの戻る導線で Collection へ戻れる挙動を維持

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Collection→Detail→Back の遷移を手動確認

## コミット
- `feat: 一覧から詳細への引数付き遷移を追加`
- `feat: 詳細画面でBottomNavigationを非表示に変更`

## 関連Issue
- Closes #29
- Refs #26
