### PR TITLE
[ARCH][#34-1] HomeのUDF契約（UiState/UiEvent）を定義する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
@@ -30,21 +30,10 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.issy.meshigen.R
 
-data class RecommendationUiModel(
-    val id: String,
-    val name: String,
-    val description: String,
-    val category: String,
-)
-sealed interface HomeResultUiState {
-    data object Initial : HomeResultUiState
-    data class Success(val items: List<RecommendationUiModel>) : HomeResultUiState
-}
-
 @Composable
 internal fun HomeScreen() {
     var moodText by rememberSaveable { mutableStateOf("") }
-    var resultUiState by remember { mutableStateOf<HomeResultUiState>(HomeResultUiState.Initial) }
+    var resultUiState by remember { mutableStateOf<HomeRecommendationUiState>(HomeRecommendationUiState.Initial) }
     val keyboardController = LocalSoftwareKeyboardController.current
 
     HomeScreenContent(
@@ -52,7 +41,7 @@ internal fun HomeScreen() {
         onMoodTextChange = { moodText = it },
         resultUiState = resultUiState,
         onRecommendClick = {
-            resultUiState = HomeResultUiState.Success(
+            resultUiState = HomeRecommendationUiState.Success(
                 items = HomeDummyDataSource.createDummyRecommendations()
             )
             keyboardController?.hide()
@@ -65,7 +54,7 @@ internal fun HomeScreen() {
 fun HomeScreenContent(
     moodText: String,
     onMoodTextChange: (String) -> Unit,
-    resultUiState: HomeResultUiState,
+    resultUiState: HomeRecommendationUiState,
     onRecommendClick: () -> Unit,
     modifier: Modifier = Modifier,
     onImeDone: () -> Unit = { },
@@ -130,14 +119,14 @@ fun HomeScreenContent(
             Spacer(modifier = Modifier.height(24.dp))
 
             when (resultUiState) {
-                HomeResultUiState.Initial -> {
+                HomeRecommendationUiState.Initial -> {
                     Text(
                         text = stringResource(R.string.home_initial_hint),
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
 
-                is HomeResultUiState.Success -> {
+                is HomeRecommendationUiState.Success -> {
                     RecommendationList(recs = resultUiState.items)
                 }
             }

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
@@ -17,7 +17,7 @@ private fun HomeScreenInitialPreview() {
         HomeScreenContent(
             moodText = "",
             onMoodTextChange = {},
-            resultUiState = HomeResultUiState.Initial,
+            resultUiState = HomeRecommendationUiState.Initial,
             onRecommendClick = {},
             modifier = Modifier,
         )
@@ -31,7 +31,7 @@ private fun HomeScreenSuccessPreview() {
         HomeScreenContent(
             moodText = "甘い物",
             onMoodTextChange = {},
-            resultUiState = HomeResultUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+            resultUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
             onRecommendClick = {},
             modifier = Modifier,
         )
@@ -45,7 +45,7 @@ private fun HomeScreenInitialNarrowPreview() {
         HomeScreenContent(
             moodText = "",
             onMoodTextChange = {},
-            resultUiState = HomeResultUiState.Initial,
+            resultUiState = HomeRecommendationUiState.Initial,
             onRecommendClick = {},
             modifier = Modifier,
         )
@@ -59,7 +59,7 @@ private fun HomeScreenSuccessNarrowPreview() {
         HomeScreenContent(
             moodText = "甘い物",
             onMoodTextChange = {},
-            resultUiState = HomeResultUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+            resultUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
             onRecommendClick = {},
             modifier = Modifier,
         )
@@ -73,7 +73,7 @@ private fun HomeScreenInitialDarkModePreview() {
         HomeScreenContent(
             moodText = "",
             onMoodTextChange = {},
-            resultUiState = HomeResultUiState.Initial,
+            resultUiState = HomeRecommendationUiState.Initial,
             onRecommendClick = {},
             modifier = Modifier,
         )
@@ -87,7 +87,7 @@ private fun HomeScreenSuccessDarkModePreview() {
         HomeScreenContent(
             moodText = "甘い物",
             onMoodTextChange = {},
-            resultUiState = HomeResultUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+            resultUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
             onRecommendClick = {},
             modifier = Modifier,
         )

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
@@ -1,0 +1,23 @@
+package com.issy.meshigen.feature.home
+
+data class HomeUiState(
+    val moodText: String = "",
+)
+
+data class RecommendationUiModel(
+    val id: String,
+    val name: String,
+    val description: String,
+    val category: String,
+)
+
+sealed interface HomeRecommendationUiState {
+    data object Initial : HomeRecommendationUiState
+    data class Success(val items: List<RecommendationUiModel>) : HomeRecommendationUiState
+}
+
+sealed interface HomeUiEvent {
+    data class MoodTextChanged(val moodText: String) : HomeUiEvent
+    data object RecommendClicked : HomeUiEvent
+    data object ImeDone : HomeUiEvent
+}


### PR DESCRIPTION
## 概要
Issue #35 の対応として、Home画面のUDF契約（状態・イベント）を `HomeScreen.kt` から分離し、`HomeUiState.kt` に集約しました。

## 変更内容
- `HomeUiState.kt` を新規作成
- `HomeUiState` に `moodText` を定義
- 推薦表示用モデル `RecommendationUiModel` を `HomeUiState.kt` に移動
- 推薦結果状態を `HomeRecommendationUiState` として `HomeUiState.kt` に定義
- `HomeUiEvent` を sealed interface で定義し、`MoodTextChanged` / `RecommendClicked` / `ImeDone` を追加
- `HomeScreen.kt` / `HomeScreenPreview.kt` の型参照を新定義へ追従（最小変更）
- Issue #35 のチェックボックス（実装/検証/DoD）を実装結果に合わせて更新

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`

## コミット
- `refactor: HomeのUDF契約型をScreenから分離`

## 関連Issue
- Closes #35
- Refs #34
