### PR TITLE
[ARCH][#34-2] HomeViewModelでStateFlow状態遷移を実装する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
@@ -2,6 +2,7 @@ package com.issy.meshigen.feature.home
 
 data class HomeUiState(
     val moodText: String = "",
+    val recommendationUiState: HomeRecommendationUiState = HomeRecommendationUiState.Initial,
 )
 
 data class RecommendationUiModel(

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModel.kt
@@ -1,0 +1,40 @@
+package com.issy.meshigen.feature.home
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class HomeViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    fun onEvent(event: HomeUiEvent) {
+        when (event) {
+            is HomeUiEvent.MoodTextChanged -> updateMoodText(event.moodText)
+            HomeUiEvent.RecommendClicked -> recommendIfPossible()
+            HomeUiEvent.ImeDone -> Unit
+        }
+    }
+
+    private fun updateMoodText(moodText: String) {
+        _uiState.update { currentState ->
+            currentState.copy(moodText = moodText)
+        }
+    }
+
+    private fun recommendIfPossible() {
+        if (_uiState.value.moodText.isBlank()) {
+            return
+        }
+
+        val items = HomeDummyDataSource.createDummyRecommendations()
+        _uiState.update { currentState ->
+            currentState.copy(
+                recommendationUiState = HomeRecommendationUiState.Success(items)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Issue #36 の対応として、`HomeViewModel` を新規作成し、`MutableStateFlow` による状態一元管理と最小のUDFイベントループを実装しました。

## 変更内容
- `HomeViewModel.kt` を新規作成
- `private val _uiState = MutableStateFlow(HomeUiState())` を定義
- `val uiState: StateFlow<HomeUiState>` を `asStateFlow()` で公開
- `onEvent(event: HomeUiEvent)` を実装し、`MoodTextChanged` / `RecommendClicked` / `ImeDone` を受け付け
- `MoodTextChanged` で `moodText` を更新
- `RecommendClicked` で空文字ガードを行い、非空時のみ `HomeDummyDataSource.createDummyRecommendations()` を使って推薦状態を更新
- `HomeUiState` に `recommendationUiState` を追加し、ViewModelで単一状態として管理できるように変更
- Issue #36 の実装/検証チェックボックスを更新

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`

## コミット
- `feat: HomeViewModelでStateFlow状態遷移を実装`

## 関連Issue
- Refs #36
- Refs #34
