### PR TITLE
[ARCH][#34-2/#34-3] HomeのViewModel状態管理とScreenステートレス化

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
@@ -19,48 +19,37 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.issy.meshigen.R
 
 @Composable
 internal fun HomeScreen() {
-    var moodText by rememberSaveable { mutableStateOf("") }
-    var resultUiState by remember { mutableStateOf<HomeRecommendationUiState>(HomeRecommendationUiState.Initial) }
+    val homeViewModel: HomeViewModel = viewModel()
+    val uiState by homeViewModel.uiState.collectAsStateWithLifecycle()
     val keyboardController = LocalSoftwareKeyboardController.current
 
     HomeScreenContent(
-        moodText = moodText,
-        onMoodTextChange = { moodText = it },
-        resultUiState = resultUiState,
-        onRecommendClick = {
-            resultUiState = HomeRecommendationUiState.Success(
-                items = HomeDummyDataSource.createDummyRecommendations()
-            )
-            keyboardController?.hide()
-        },
-        onImeDone = { keyboardController?.hide() }
+        uiState = uiState,
+        onEvent = homeViewModel::onEvent,
+        onKeyboardDismissRequest = { keyboardController?.hide() },
     )
 }
 
 @Composable
 fun HomeScreenContent(
-    moodText: String,
-    onMoodTextChange: (String) -> Unit,
-    resultUiState: HomeRecommendationUiState,
-    onRecommendClick: () -> Unit,
+    uiState: HomeUiState,
+    onEvent: (HomeUiEvent) -> Unit,
     modifier: Modifier = Modifier,
-    onImeDone: () -> Unit = { },
+    onKeyboardDismissRequest: () -> Unit = { },
 ){
 
-    val isButtonEnabled = moodText.isNotBlank()
+    val isButtonEnabled = uiState.moodText.isNotBlank()
 
     Scaffold(
         modifier = modifier.fillMaxSize()
@@ -86,8 +75,8 @@ fun HomeScreenContent(
             Spacer(modifier = Modifier.height(24.dp))
 
             OutlinedTextField(
-                value = moodText,
-                onValueChange = { onMoodTextChange(it) },
+                value = uiState.moodText,
+                onValueChange = { onEvent(HomeUiEvent.MoodTextChanged(it)) },
                 modifier = Modifier.fillMaxWidth(),
                 label = {
                     Text(stringResource(R.string.home_mood_label))
@@ -100,7 +89,10 @@ fun HomeScreenContent(
                     imeAction = ImeAction.Done
                 ),
                 keyboardActions = KeyboardActions(
-                    onDone = { onImeDone() }
+                    onDone = {
+                        onEvent(HomeUiEvent.ImeDone)
+                        onKeyboardDismissRequest()
+                    }
                 )
             )
 
@@ -108,7 +100,8 @@ fun HomeScreenContent(
 
             Button(
                 onClick = {
-                    onRecommendClick()
+                    onEvent(HomeUiEvent.RecommendClicked)
+                    onKeyboardDismissRequest()
                 },
                 enabled = isButtonEnabled,
                 modifier = Modifier.fillMaxWidth()
@@ -118,7 +111,7 @@ fun HomeScreenContent(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            when (resultUiState) {
+            when (uiState.recommendationUiState) {
                 HomeRecommendationUiState.Initial -> {
                     Text(
                         text = stringResource(R.string.home_initial_hint),
@@ -127,7 +120,7 @@ fun HomeScreenContent(
                 }
 
                 is HomeRecommendationUiState.Success -> {
-                    RecommendationList(recs = resultUiState.items)
+                    RecommendationList(recs = uiState.recommendationUiState.items)
                 }
             }
         }

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
@@ -15,10 +15,11 @@ import com.issy.meshigen.ui.theme.MeshigenTheme
 private fun HomeScreenInitialPreview() {
     MeshigenTheme {
         HomeScreenContent(
-            moodText = "",
-            onMoodTextChange = {},
-            resultUiState = HomeRecommendationUiState.Initial,
-            onRecommendClick = {},
+            uiState = HomeUiState(
+                moodText = "",
+                recommendationUiState = HomeRecommendationUiState.Initial,
+            ),
+            onEvent = {},
             modifier = Modifier,
         )
     }
@@ -29,10 +30,11 @@ private fun HomeScreenInitialPreview() {
 private fun HomeScreenSuccessPreview() {
     MeshigenTheme {
         HomeScreenContent(
-            moodText = "甘い物",
-            onMoodTextChange = {},
-            resultUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
-            onRecommendClick = {},
+            uiState = HomeUiState(
+                moodText = "甘い物",
+                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+            ),
+            onEvent = {},
             modifier = Modifier,
         )
     }
@@ -43,10 +45,11 @@ private fun HomeScreenSuccessPreview() {
 private fun HomeScreenInitialNarrowPreview() {
     MeshigenTheme {
         HomeScreenContent(
-            moodText = "",
-            onMoodTextChange = {},
-            resultUiState = HomeRecommendationUiState.Initial,
-            onRecommendClick = {},
+            uiState = HomeUiState(
+                moodText = "",
+                recommendationUiState = HomeRecommendationUiState.Initial,
+            ),
+            onEvent = {},
             modifier = Modifier,
         )
     }
@@ -57,10 +60,11 @@ private fun HomeScreenInitialNarrowPreview() {
 private fun HomeScreenSuccessNarrowPreview() {
     MeshigenTheme {
         HomeScreenContent(
-            moodText = "甘い物",
-            onMoodTextChange = {},
-            resultUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
-            onRecommendClick = {},
+            uiState = HomeUiState(
+                moodText = "甘い物",
+                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+            ),
+            onEvent = {},
             modifier = Modifier,
         )
     }
@@ -71,10 +75,11 @@ private fun HomeScreenSuccessNarrowPreview() {
 private fun HomeScreenInitialDarkModePreview() {
     MeshigenTheme {
         HomeScreenContent(
-            moodText = "",
-            onMoodTextChange = {},
-            resultUiState = HomeRecommendationUiState.Initial,
-            onRecommendClick = {},
+            uiState = HomeUiState(
+                moodText = "",
+                recommendationUiState = HomeRecommendationUiState.Initial,
+            ),
+            onEvent = {},
             modifier = Modifier,
         )
     }
@@ -85,10 +90,11 @@ private fun HomeScreenInitialDarkModePreview() {
 private fun HomeScreenSuccessDarkModePreview() {
     MeshigenTheme {
         HomeScreenContent(
-            moodText = "甘い物",
-            onMoodTextChange = {},
-            resultUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
-            onRecommendClick = {},
+            uiState = HomeUiState(
+                moodText = "甘い物",
+                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+            ),
+            onEvent = {},
             modifier = Modifier,
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## 概要
Issue #36 と #37 の対応として、Homeの状態管理を ViewModel + StateFlow に集約し、HomeScreen を `state + event` ベースのステートレス構成へ移行しました。

## 変更内容
- `HomeViewModel` で `MutableStateFlow<HomeUiState>` を管理し、`onEvent` で状態遷移するUDFループを実装
- `MoodTextChanged` / `RecommendClicked` / `ImeDone` を `HomeUiEvent` で受ける構成へ統一
- `HomeScreen` で `viewModel()` を取得し、`collectAsStateWithLifecycle()` で `uiState` を購読
- `HomeScreenContent` の引数を `HomeUiState + onEvent` に変更し、画面状態の `remember` を除去
- 入力更新・推薦ボタン押下・IME完了を `onEvent(...)` 経由に置換
- 結果表示分岐とボタン活性判定を `uiState` 由来に統一
- `HomeScreenPreview` を新しい `HomeScreenContent` シグネチャに最小追従
- `collectAsStateWithLifecycle` 利用のため `lifecycle-runtime-compose` 依存を追加

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`
- [x] 実機で入力→ボタン活性→結果表示が従来どおり動作することを確認
- [x] 実機で画面再生成時に ViewModel 保持状態から表示復元されることを確認

## コミット
- `feat: HomeViewModelでStateFlow状態遷移を実装`
- `chore: lifecycle compose依存を追加`
- `feat: HomeScreenをViewModel接続でステートレス化`

## 関連Issue
- Closes #36
- Closes #37
- Refs #34
