### PR TITLE
[ARCH][#34-4] Lifecycle依存追加と最終検証でUDF移行を完了する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
@@ -47,7 +47,7 @@ fun HomeScreenContent(
     onEvent: (HomeUiEvent) -> Unit,
     modifier: Modifier = Modifier,
     onKeyboardDismissRequest: () -> Unit = { },
-){
+) {
 
     val isButtonEnabled = uiState.moodText.isNotBlank()
 
@@ -90,7 +90,6 @@ fun HomeScreenContent(
                 ),
                 keyboardActions = KeyboardActions(
                     onDone = {
-                        onEvent(HomeUiEvent.ImeDone)
                         onKeyboardDismissRequest()
                     }
                 )

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
@@ -20,5 +20,4 @@ sealed interface HomeRecommendationUiState {
 sealed interface HomeUiEvent {
     data class MoodTextChanged(val moodText: String) : HomeUiEvent
     data object RecommendClicked : HomeUiEvent
-    data object ImeDone : HomeUiEvent
 }

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModel.kt
@@ -15,7 +15,6 @@ class HomeViewModel : ViewModel() {
         when (event) {
             is HomeUiEvent.MoodTextChanged -> updateMoodText(event.moodText)
             HomeUiEvent.RecommendClicked -> recommendIfPossible()
-            HomeUiEvent.ImeDone -> Unit
         }
     }
 


### PR DESCRIPTION
## 概要
Issue #38 の対応として、HomeのUDFイベント契約を最終整理し、Lifecycle依存導入後の最終検証結果を反映しました。

## 変更内容
- `HomeUiEvent` から未使用の `ImeDone` を削除
- `HomeViewModel` の `onEvent` から `ImeDone` 分岐を削除
- `HomeScreen` のIME完了時イベント送出を削除し、キーボードクローズのみに整理
- #34 / #38 のIssueチェックリストを完了状態に更新（GitHub Issue側）

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:assembleDebug`
- [x] 手動確認: 入力文字の変更が即座に状態へ反映される
- [x] 手動確認: 入力空時はボタン非活性、入力ありで活性
- [x] 手動確認: ボタン押下でおすすめ結果が表示される
- [x] 手動確認: 画面再生成時に表示状態が破綻しない

## コミット
- `refactor: Homeの不要イベントを削除`

## 関連Issue
- Closes #38
- Closes #34
