### PR TITLE
[ARCH][#43-1] Room依存追加とAppDatabase基盤を作成する

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -55,4 +56,9 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
 }

--- a/app/src/main/java/com/issy/meshigen/data/local/DatabaseProvider.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/DatabaseProvider.kt
@@ -1,0 +1,22 @@
+package com.issy.meshigen.data.local
+
+import android.content.Context
+import androidx.room.Room
+
+object DatabaseProvider {
+
+    @Volatile
+    private var instance: MeshigenDatabase? = null
+
+    fun get(context: Context): MeshigenDatabase {
+        return instance ?: synchronized(this) {
+            instance ?: Room.databaseBuilder(
+                context.applicationContext,
+                MeshigenDatabase::class.java,
+                MeshigenDatabase.DB_NAME
+            ).build().also { db ->
+                instance = db
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/issy/meshigen/data/local/MeshigenDatabase.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/MeshigenDatabase.kt
@@ -1,0 +1,15 @@
+package com.issy.meshigen.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [RoomPlaceholderEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class MeshigenDatabase : RoomDatabase() {
+    companion object {
+        const val DB_NAME = "meshigen.db"
+    }
+}

--- a/app/src/main/java/com/issy/meshigen/data/local/RoomPlaceholderEntity.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/RoomPlaceholderEntity.kt
@@ -1,0 +1,9 @@
+package com.issy.meshigen.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "room_placeholder")
+data class RoomPlaceholderEntity(
+    @PrimaryKey val id: Int = 1
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Temporary workaround for AGP 9 built-in Kotlin + KSP sourceSet restriction.
+android.disallowKotlinSourceSets=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,11 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
-kotlin = "2.0.21"
+kotlin = "2.2.10"
 composeBom = "2024.09.00"
 navigationCompose = "2.8.0"
+room = "2.6.1"
+ksp = "2.2.10-2.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,7 +29,11 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## 概要
Issue #44 の対応として、Room導入の最小構成（依存追加・`MeshigenDatabase`・DB取得Provider）を実装しました。

## 変更内容
- Version Catalogに `room` / `ksp` のバージョン、Roomライブラリ、KSPプラグインを追加
- `app/build.gradle.kts` に KSP適用と Room依存（`runtime` / `ktx` / `compiler`）を追加
- ルート `build.gradle.kts` に `libs.plugins.ksp` の `apply false` を追加
- `MeshigenDatabase` を新規作成し、DB名・version・`exportSchema` を定義
- `DatabaseProvider` を新規作成し、DI未導入で使える最小シングルトン取得を実装
- Roomコード生成確認用の最小Entity（`RoomPlaceholderEntity`）を追加
- AGP 9 built-in Kotlin + KSP の制約回避として `gradle.properties` に暫定設定を追加

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`
- [x] 実機でアプリ起動し、初回表示まで到達することを確認
- [x] `kspDebugKotlin` が成功し、Roomコード生成が通ることを確認

## コミット
- `chore: RoomとKSPのビルド設定を追加`
- `feat: MeshigenDatabase基盤と最小Providerを追加`

## 関連Issue
- Closes #44
- Refs #43
- Refs #49
