### PR TITLE
[ARCH][#43-3] gourmet_collectionと図鑑操作DAOを実装する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/local/DatabaseProvider.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/DatabaseProvider.kt
@@ -2,6 +2,8 @@ package com.issy.meshigen.data.local
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.issy.meshigen.data.local.seed.GourmetSeedData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -12,22 +14,44 @@ object DatabaseProvider {
     @Volatile
     private var instance: MeshigenDatabase? = null
 
+    private val MIGRATION_1_2 = object : Migration(1, 2) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS gourmet_collection (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    gourmet_id INTEGER NOT NULL,
+                    mood_text TEXT NOT NULL,
+                    ai_comment TEXT NOT NULL,
+                    is_favorite INTEGER NOT NULL DEFAULT 0,
+                    created_at INTEGER NOT NULL,
+                    FOREIGN KEY(gourmet_id) REFERENCES gourmets(id)
+                )
+                """.trimIndent()
+            )
+            db.execSQL(
+                "CREATE INDEX IF NOT EXISTS index_gourmet_collection_gourmet_id ON gourmet_collection(gourmet_id)"
+            )
+        }
+    }
+
     fun get(context: Context): MeshigenDatabase {
         return instance ?: synchronized(this) {
             instance ?: Room.databaseBuilder(
                 context.applicationContext,
                 MeshigenDatabase::class.java,
                 MeshigenDatabase.DB_NAME
-            ).build().also { db ->
-                instance = db
+            ).addMigrations(MIGRATION_1_2)
+                .build().also { db ->
+                    instance = db
 
-                CoroutineScope(Dispatchers.IO).launch {
-                    val dao = db.gourmetDao()
-                    if (dao.count() == 0) {
-                        dao.insertAll(GourmetSeedData.items)
+                    CoroutineScope(Dispatchers.IO).launch {
+                        val dao = db.gourmetDao()
+                        if (dao.count() == 0) {
+                            dao.insertAll(GourmetSeedData.items)
+                        }
                     }
                 }
-            }
         }
     }
 }

--- a/app/src/main/java/com/issy/meshigen/data/local/MeshigenDatabase.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/MeshigenDatabase.kt
@@ -2,16 +2,19 @@ package com.issy.meshigen.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.issy.meshigen.data.local.dao.CollectionDao
 import com.issy.meshigen.data.local.dao.GourmetDao
+import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
 import com.issy.meshigen.data.local.entity.GourmetEntity
 
 @Database(
-    entities = [GourmetEntity::class],
-    version = 1,
+    entities = [GourmetEntity::class, GourmetCollectionEntity::class],
+    version = 2,
     exportSchema = false,
 )
 abstract class MeshigenDatabase : RoomDatabase() {
     abstract fun gourmetDao(): GourmetDao
+    abstract fun CollectionDao(): CollectionDao
 
     companion object {
         const val DB_NAME = "meshigen.db"

--- a/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
@@ -61,4 +61,14 @@ interface CollectionDao {
     // 削除
     @Query("DELETE FROM gourmet_collection WHERE id = :collectionId")
     suspend fun deleteByCollectionId(collectionId: Int): Int
+
+    // お気に入りの更新
+    @Query(
+        """
+        UPDATE gourmet_collection
+        SET is_favorite = :favorite
+        WHERE id = :collectionId
+        """
+    )
+    suspend fun updateFavorite(collectionId: Int, favorite: Boolean): Int
 }

--- a/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
@@ -1,0 +1,64 @@
+package com.issy.meshigen.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
+import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+
+@Dao
+interface CollectionDao {
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(item: GourmetCollectionEntity): Long
+
+    // 全件取得
+    @Query(
+        """
+        SELECT
+            gc.id AS collection_id,
+            gc.gourmet_id,
+            g.name,
+            g.area,
+            g.category,
+            g.description,
+            g.search_keyword,
+            gc.mood_text,
+            gc.ai_comment,
+            gc.is_favorite,
+            gc.created_at
+        FROM gourmet_collection gc
+        INNER JOIN gourmets g ON gc.gourmet_id = g.id
+        ORDER BY gc.created_at DESC
+        """
+    )
+    suspend fun getAllWithGourmet(): List<CollectionWithGourmetRow>
+
+    // コレクションIDで取得
+    @Query(
+        """
+        SELECT
+            gc.id AS collection_id,
+            gc.gourmet_id,
+            g.name,
+            g.area,
+            g.category,
+            g.description,
+            g.search_keyword,
+            gc.mood_text,
+            gc.ai_comment,
+            gc.is_favorite,
+            gc.created_at
+        FROM gourmet_collection gc
+        INNER JOIN gourmets g ON gc.gourmet_id = g.id
+        WHERE gc.id = :collectionId
+        LIMIT 1
+        """
+    )
+    suspend fun getByCollectionId(collectionId: Int): CollectionWithGourmetRow?
+
+    // 削除
+    @Query("DELETE FROM gourmet_collection WHERE id = :collectionId")
+    suspend fun deleteByCollectionId(collectionId: Int): Int
+}

--- a/app/src/main/java/com/issy/meshigen/data/local/entity/GourmetCollectionEntity.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/entity/GourmetCollectionEntity.kt
@@ -3,6 +3,7 @@ package com.issy.meshigen.data.local.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
@@ -13,7 +14,8 @@ import androidx.room.PrimaryKey
             parentColumns = ["id"],
             childColumns = ["gourmet_id"],
         )
-    ]
+    ],
+    indices = [Index(value = ["gourmet_id"])]
 )
 data class GourmetCollectionEntity(
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/com/issy/meshigen/data/local/entity/GourmetCollectionEntity.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/entity/GourmetCollectionEntity.kt
@@ -1,0 +1,31 @@
+package com.issy.meshigen.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "gourmet_collection",
+    foreignKeys = [
+        ForeignKey(
+            entity = GourmetEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["gourmet_id"],
+        )
+    ]
+)
+data class GourmetCollectionEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    @ColumnInfo(name = "gourmet_id")
+    val gourmetId: Int,
+    @ColumnInfo(name = "mood_text")
+    val moodText: String,
+    @ColumnInfo(name = "ai_comment")
+    val aiComment: String,
+    @ColumnInfo(name = "is_favorite", defaultValue = "0")
+    val favorite: Boolean = false,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis(),
+)

--- a/app/src/main/java/com/issy/meshigen/data/local/query/CollectionWithGourmetRow.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/query/CollectionWithGourmetRow.kt
@@ -1,0 +1,24 @@
+package com.issy.meshigen.data.local.query
+
+import androidx.room.ColumnInfo
+
+data class CollectionWithGourmetRow(
+    @ColumnInfo(name = "collection_id")
+    val collectionId: Int,
+    @ColumnInfo(name = "gourmet_id")
+    val gourmetId: Int,
+    val name: String,
+    val area: String,
+    val category: String,
+    val description: String,
+    @ColumnInfo(name = "search_keyword")
+    val searchKeyword: String,
+    @ColumnInfo(name = "mood_text")
+    val moodText: String,
+    @ColumnInfo(name = "ai_comment")
+    val aiComment: String,
+    @ColumnInfo(name = "is_favorite")
+    val favorite: Boolean,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long,
+)


### PR DESCRIPTION
## 概要
Issue #46 の対応として、`gourmet_collection` のRoom実装と図鑑操作DAO（保存・一覧・詳細・お気に入り更新・削除）を追加しました。あわせて、既存DB利用端末向けに `v1 -> v2` マイグレーションを実装しました。

## 変更内容
- `GourmetCollectionEntity` を追加し、外部キー・`is_favorite`・`created_at` を定義
- `CollectionWithGourmetRow` を追加し、`gourmets` JOIN結果を受け取るモデルを作成
- `CollectionDao` を追加し、以下を実装
  - `insert`
  - `getAllWithGourmet`（JOIN）
  - `getByCollectionId`（JOIN）
  - `updateFavorite`
  - `deleteByCollectionId`
- `MeshigenDatabase` に `GourmetCollectionEntity` / `CollectionDao` を登録
- DBバージョンを `2` に更新し、`Migration(1,2)` と `addMigrations(...)` を追加
- `gourmet_collection.gourmet_id` に index を追加

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin`
- [x] 実機デバッグで DAO 一連動作を確認（`insert -> query -> favorite更新 -> delete`）
- [x] Database Inspector で `gourmet_collection` テーブル追加を確認

## コミット
- `feat: gourmet_collectionのエンティティとJOIN行モデルを追加`
- `feat: 図鑑操作用のCollectionDaoを追加`
- `feat: gourmet_collection追加に伴うDB移行を実装`
- `feat: CollectionDaoにお気に入り更新APIを追加`

## 関連Issue
- Closes #46
- Refs #43
