### PR TITLE
[ARCH][#43-4] 図鑑一覧をRoomデータソースへ接続する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
 import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CollectionDao {
@@ -33,7 +34,7 @@ interface CollectionDao {
         ORDER BY gc.created_at DESC
         """
     )
-    suspend fun getAllWithGourmet(): List<CollectionWithGourmetRow>
+    fun getAllWithGourmet(): Flow<List<CollectionWithGourmetRow>>
 
     // コレクションIDで取得
     @Query(

--- a/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepository.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepository.kt
@@ -1,0 +1,9 @@
+package com.issy.meshigen.data.repository
+
+import com.issy.meshigen.feature.collection.CollectionListUiModel
+import kotlinx.coroutines.flow.Flow
+
+interface CollectionRepository {
+    fun observeCollections(): Flow<List<CollectionListUiModel>>
+    suspend fun updateFavorite(collectionId: Int, favorite: Boolean)
+}

--- a/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepositoryImpl.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.issy.meshigen.data.repository
+
+import com.issy.meshigen.data.local.dao.CollectionDao
+import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+import com.issy.meshigen.feature.collection.CollectionListUiModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.Instant
+import java.time.ZoneId
+
+class CollectionRepositoryImpl(
+    private val collectionDao: CollectionDao
+): CollectionRepository {
+
+    override fun observeCollections(): Flow<List<CollectionListUiModel>> {
+        return collectionDao.getAllWithGourmet()
+            .map { rows -> rows.map(::toUiModel) }
+    }
+
+    override suspend fun updateFavorite(collectionId: Int, favorite: Boolean) {
+        collectionDao.updateFavorite(collectionId, favorite)
+    }
+
+    private fun toUiModel(row: CollectionWithGourmetRow): CollectionListUiModel {
+        return CollectionListUiModel(
+            collectionId = row.collectionId.toString(),
+            gourmetId = row.gourmetId.toString(),
+            name = row.name,
+            category = row.category,
+            area = row.area,
+            suggestedDate = Instant.ofEpochMilli(row.createdAt)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+                .toString(),
+            favorite = row.favorite,
+        )
+    }
+}

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreen.kt
@@ -22,16 +22,23 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.issy.meshigen.R
+import com.issy.meshigen.data.local.DatabaseProvider
+import com.issy.meshigen.data.repository.CollectionRepositoryImpl
 
 data class CollectionListUiModel(
-    val id: String,
+    val collectionId: String,
+    val gourmetId: String,
     val name: String,
     val category: String,
     val area: String,
@@ -67,25 +74,23 @@ internal fun CollectionListScreen(
         ),
     )
 
-    val items = remember {
-        listOf(
-            CollectionListUiModel(
-                id = "kokura-yakiudon",
-                name = "小倉焼うどん",
-                category = "麺",
-                area = "小倉北区",
-                suggestedDate = "2026-04-07", // yyyy-MM-dd
-                favorite = false,
-            )
-        )
+    val context = LocalContext.current
+
+    val factory = remember(context) {
+        val db = DatabaseProvider.get(context)
+        val repository = CollectionRepositoryImpl(db.CollectionDao())
+        CollectionListViewModelFactory(repository)
     }
+
+    val collectionListViewModel: CollectionListViewModel = viewModel(factory = factory)
+    val uiState by collectionListViewModel.uiState.collectAsStateWithLifecycle()
 
     CollectionListScreenContent(
         filters = filters,
-        items = items,
+        items = uiState.items,
         onFilterClick = {},
-        onItemClick = { item -> onItemClick(item.id) },
-        onFavoriteClick = {},
+        onItemClick = { item -> onItemClick(item.gourmetId) },
+        onFavoriteClick = collectionListViewModel::onFavoriteClick,
     )
 }
 
@@ -137,7 +142,7 @@ internal fun CollectionListScreenContent(
                     modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(items = items, key = { it.id }) { item ->
+                    items(items = items, key = { it.collectionId }) { item ->
                         CollectionListCard(
                             item = item,
                             onClick = { onItemClick(item) },

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreenPreview.kt
@@ -12,7 +12,8 @@ private val previewFilters = listOf(
 
 private val previewItems = listOf(
     CollectionListUiModel(
-        id = "kokura-yakiudon",
+        gourmetId = "kokura-yakiudon",
+        collectionId = "1",
         name = "小倉焼うどん",
         category = "麺",
         area = "小倉北区",
@@ -23,7 +24,8 @@ private val previewItems = listOf(
 
 private val previewItemsLongState = listOf(
     CollectionListUiModel(
-        id = "kokura-yakiudon",
+        gourmetId = "kokura-yakiudon",
+        collectionId = "1",
         name = "門司港発祥・特製スパイス香る超濃厚スタミナ焼うどん（大盛り・追い玉子付き）",
         category = "麺料理と鉄板グルメの合わせ技",
         area = "小倉北区魚町銀天街アーケード沿いの老舗エリア",

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
@@ -1,0 +1,2 @@
+package com.issy.meshigen.feature.collection
+

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
@@ -1,2 +1,35 @@
 package com.issy.meshigen.feature.collection
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.issy.meshigen.data.repository.CollectionRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class CollectionListUiState(
+    val items: List<CollectionListUiModel> = emptyList(),
+)
+
+class CollectionListViewModel(
+    private val repository: CollectionRepository,
+) : ViewModel() {
+
+    val uiState: StateFlow<CollectionListUiState> =
+        repository.observeCollections()
+            .map { items -> CollectionListUiState(items = items) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = CollectionListUiState(),
+            )
+
+    fun onFavoriteClick(item: CollectionListUiModel) {
+        val collectionId = item.collectionId.toIntOrNull() ?: return
+        viewModelScope.launch {
+            repository.updateFavorite(collectionId, !item.favorite)
+        }
+    }
+}

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModelFactory.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModelFactory.kt
@@ -1,0 +1,2 @@
+package com.issy.meshigen.feature.collection
+

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModelFactory.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModelFactory.kt
@@ -1,2 +1,17 @@
 package com.issy.meshigen.feature.collection
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.issy.meshigen.data.repository.CollectionRepository
+
+class CollectionListViewModelFactory(
+    private val repository: CollectionRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(CollectionListViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return CollectionListViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}


### PR DESCRIPTION
## 概要
- #47 図鑑一覧をRoomデータソースへ接続する対応です。
- 図鑑一覧の表示元を仮データから `gourmet_collection` + `gourmets` のRoomデータへ切り替えました。

## 変更内容
- `CollectionDao#getAllWithGourmet` を `Flow<List<CollectionWithGourmetRow>>` 化
- `CollectionRepository` / `CollectionRepositoryImpl` を追加し、一覧購読とお気に入り更新を集約
- `CollectionListViewModel` / `CollectionListViewModelFactory` を追加
- `CollectionListScreen` をViewModel購読に接続し、仮データ依存を除去
- `CollectionListUiModel` のIDを `collectionId` / `gourmetId` に分離し、
  - お気に入り更新は `collectionId`
  - 詳細遷移は `gourmetId`
  を利用するよう整理
- PreviewのUIモデル初期化を新しいID構造に追従

## 動作確認
- `./gradlew :app:compileDebugKotlin` が成功
- `gourmet_collection` に検証データ投入後、図鑑一覧に表示されることを確認
- 一覧でお気に入り操作した結果が `is_favorite` に反映されることを確認
- 画面再表示後もお気に入り状態が維持されることを確認

## 関連Issue
- Closes #47
- 親Issue: #43
