### PR TITLE
[TECH] AGP 9 built-in Kotlin と KSP の sourceSets 警告を解消する

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)

--- a/docs/issue-49-built-in-kotlin-ksp-memo.md
+++ b/docs/issue-49-built-in-kotlin-ksp-memo.md
@@ -1,0 +1,53 @@
+# Issue #49: AGP 9 built-in Kotlin + KSP sourceSets 警告対応メモ
+
+## 1. 目的
+- 対象Issue: [#49](https://github.com/Issy64/meshigen/issues/49)
+- 目的: `android.disallowKotlinSourceSets=false` に依存しない状態で、Room + KSP の build/sync を安定化する
+
+## 2. 発生していた現象
+- ビルド/Sync時に以下メッセージが出る
+
+```text
+Using kotlin.sourceSets DSL to add Kotlin sources is not allowed with built-in Kotlin.
+Kotlin source set 'debug/release' contains: app/build/generated/ksp/...
+Solution: Use android.sourceSets DSL instead.
+To suppress this error, set android.disallowKotlinSourceSets=false in gradle.properties.
+```
+
+## 3. 再現手順（過去状態）
+1. `gradle.properties` に `android.disallowKotlinSourceSets=false` を入れない状態にする
+2. 以下を実行する
+
+```bash
+./gradlew -Pandroid.disallowKotlinSourceSets=true :app:compileDebugKotlin
+```
+
+3. 上記の `kotlin.sourceSets DSL` エラーが出る
+
+## 4. 最終設定（2026-04-20）
+- `gradle.properties`
+  - `android.disallowKotlinSourceSets=false` を使わない（コメントアウト）
+- `gradle/libs.versions.toml`
+  - `agp = "9.0.1"`
+  - `kotlin = "2.3.20"`
+  - `ksp = "2.3.6"`
+  - `composeBom = "2026.03.01"`
+  - `navigationCompose = "2.9.7"`
+  - `androidx-compose-material-icons-extended` を追加
+- `app/build.gradle.kts`
+  - `implementation(libs.androidx.compose.material.icons.extended)` を追加
+
+## 5. 検証結果
+### 5.1 CLI build
+```bash
+./gradlew :app:compileDebugKotlin
+```
+- 結果: `BUILD SUCCESSFUL`
+
+### 5.2 Android Studio Sync
+- `Sync Project with Gradle Files` 実行
+- 結果: `BUILD SUCCESSFUL` を確認
+
+## 6. 補足
+- `Icons.*` を利用するUI実装に対し、`material-icons-extended` 依存が必要だったため追加した
+- 本対応で、Issue #49 のDone criteriaにある「回避設定なしで build/sync 成功」を満たす

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # Temporary workaround for AGP 9 built-in Kotlin + KSP sourceSet restriction.
-android.disallowKotlinSourceSets=false
+#android.disallowKotlinSourceSets=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,11 +6,11 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
-kotlin = "2.2.10"
-composeBom = "2024.09.00"
-navigationCompose = "2.8.0"
+kotlin = "2.3.20"
+composeBom = "2026.03.01"
+navigationCompose = "2.9.7"
 room = "2.8.4"
-ksp = "2.2.10-2.0.2"
+ksp = "2.3.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +27,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
## 概要
- #49 AGP 9 built-in Kotlin と KSP の sourceSets 警告解消対応です。
- `android.disallowKotlinSourceSets=false` の回避設定に依存しない構成へ更新しました。
- 併せて、`Icons.*` 利用に必要な Compose icons 依存を追加しました。

## 変更内容
- Gradle設定/依存の見直し
  - `gradle.properties` の `android.disallowKotlinSourceSets=false` を無効化
  - `gradle/libs.versions.toml` の更新
    - `kotlin = "2.3.20"`
    - `ksp = "2.3.6"`
    - `composeBom = "2026.03.01"`
    - `navigationCompose = "2.9.7"`
  - `androidx-compose-material-icons-extended` を追加
- Appモジュール依存の追加
  - `app/build.gradle.kts` に `implementation(libs.androidx.compose.material.icons.extended)` を追加
- 検証メモの追加
  - `docs/issue-49-built-in-kotlin-ksp-memo.md`

## 動作確認
- `./gradlew :app:compileDebugKotlin` が成功
- Android Studio `Sync Project with Gradle Files` 実行で `BUILD SUCCESSFUL` を確認

## 関連Issue
- Closes #49
- Closes #43
- 関連: #44

