### PR TITLE
feat: ホーム提案用Repositoryを追加する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/repository/HomeRepository.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/HomeRepository.kt
@@ -1,0 +1,12 @@
+package com.issy.meshigen.data.repository
+
+interface HomeRepository {
+    suspend fun getRecommendation(): HomeRecommendation?
+}
+
+data class HomeRecommendation(
+    val id: Int,
+    val name: String,
+    val description: String,
+    val category: String,
+)

--- a/app/src/main/java/com/issy/meshigen/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/HomeRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.issy.meshigen.data.repository
+
+import com.issy.meshigen.data.local.dao.GourmetDao
+import com.issy.meshigen.data.local.entity.GourmetEntity
+
+class HomeRepositoryImpl(
+    private val gourmetDao: GourmetDao
+) : HomeRepository {
+
+    override suspend fun getRecommendation(): HomeRecommendation? {
+        val gourmets = gourmetDao.getAll()
+        val selectedGourmet = selectRecommendation(gourmets) ?: return null
+
+        return toHomeRecommendation(selectedGourmet)
+    }
+
+    private fun toHomeRecommendation(
+        gourmet: GourmetEntity
+    ): HomeRecommendation {
+        return HomeRecommendation(
+            id = gourmet.id,
+            name = gourmet.name,
+            description = gourmet.description,
+            category = gourmet.category,
+        )
+    }
+
+    private fun selectRecommendation(
+        gourmets: List<GourmetEntity>
+    ): GourmetEntity? {
+        return gourmets.firstOrNull()
+    }
+}


### PR DESCRIPTION
## 概要

ホーム画面の提案処理で使うRepository層を追加しました。

- `HomeRepository` を追加
- `HomeRepositoryImpl` を追加
- `GourmetDao.getAll()` から取得したグルメ一覧の先頭1件を提案対象として返却
- グルメ一覧が空の場合は `null` を返却
- 選定処理と変換処理をprivate関数に分離

## 確認

- [x] `./gradlew testDebugUnitTest`

## 関連Issue

Closes #62
