### PR TITLE
feat: ホーム提案時に図鑑へ自動登録する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/repository/HomeRepository.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/HomeRepository.kt
@@ -1,7 +1,7 @@
 package com.issy.meshigen.data.repository
 
 interface HomeRepository {
-    suspend fun getRecommendation(): HomeRecommendation?
+    suspend fun getRecommendation(moodText: String): HomeRecommendation?
 }
 
 data class HomeRecommendation(
@@ -9,4 +9,5 @@ data class HomeRecommendation(
     val name: String,
     val description: String,
     val category: String,
+    val isNewDiscovery: Boolean,
 )

--- a/app/src/main/java/com/issy/meshigen/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/HomeRepositoryImpl.kt
@@ -1,27 +1,47 @@
 package com.issy.meshigen.data.repository
 
+import com.issy.meshigen.data.local.dao.CollectionDao
 import com.issy.meshigen.data.local.dao.GourmetDao
+import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
 import com.issy.meshigen.data.local.entity.GourmetEntity
 
+private const val INSERT_IGNORED = -1L
+
 class HomeRepositoryImpl(
-    private val gourmetDao: GourmetDao
+    private val gourmetDao: GourmetDao,
+    private val collectionDao: CollectionDao,
+    private val temporaryAiComment: String,
 ) : HomeRepository {
 
-    override suspend fun getRecommendation(): HomeRecommendation? {
+    override suspend fun getRecommendation(moodText: String): HomeRecommendation? {
         val gourmets = gourmetDao.getAll()
         val selectedGourmet = selectRecommendation(gourmets) ?: return null
 
-        return toHomeRecommendation(selectedGourmet)
+        val collectionItem = GourmetCollectionEntity(
+            gourmetId = selectedGourmet.id,
+            moodText = moodText,
+            aiComment = temporaryAiComment,
+        )
+
+        val insertResult = collectionDao.insert(collectionItem)
+        val isNewDiscovery = insertResult != INSERT_IGNORED
+
+        return toHomeRecommendation(
+            gourmet = selectedGourmet,
+            isNewDiscovery = isNewDiscovery,
+        )
     }
 
     private fun toHomeRecommendation(
-        gourmet: GourmetEntity
+        gourmet: GourmetEntity,
+        isNewDiscovery: Boolean,
     ): HomeRecommendation {
         return HomeRecommendation(
             id = gourmet.id,
             name = gourmet.name,
             description = gourmet.description,
             category = gourmet.category,
+            isNewDiscovery = isNewDiscovery,
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="home_mood_placeholder">たとえば (ガッツリ食べたい / 甘いものが欲しい)</string>
     <string name="home_recommend_button">おすすめを見る</string>
     <string name="home_initial_hint">気分を入力すると、おすすめ結果がここに表示されます。</string>
+    <string name="home_temporary_ai_comment">あなたの気分にぴったりのグルメを見つけました！</string>
 
     <string name="collection_list_title">図鑑一覧</string>
     <string name="collection_list_description">保存した北九州B級グルメを確認できます。</string>

--- a/app/src/test/java/com/issy/meshigen/data/repository/HomeRepositoryImplTest.kt
+++ b/app/src/test/java/com/issy/meshigen/data/repository/HomeRepositoryImplTest.kt
@@ -1,0 +1,128 @@
+package com.issy.meshigen.data.repository
+
+import com.issy.meshigen.data.local.dao.CollectionDao
+import com.issy.meshigen.data.local.dao.GourmetDao
+import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
+import com.issy.meshigen.data.local.entity.GourmetEntity
+import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HomeRepositoryImplTest {
+
+    @Test
+    fun getRecommendation_whenInsertSucceeds_returnsNewDiscoveryTrue() = runBlocking {
+        val repository = HomeRepositoryImpl(
+            gourmetDao = FakeGourmetDao(listOf(testGourmet)),
+            collectionDao = FakeCollectionDao(insertResult = 1L),
+            temporaryAiComment = temporaryAiComment,
+        )
+
+        val result = repository.getRecommendation(moodText = moodText)
+
+        assertNotNull(result)
+        assertEquals(true, result?.isNewDiscovery)
+    }
+
+    @Test
+    fun getRecommendation_whenInsertIgnored_returnsNewDiscoveryFalse() = runBlocking {
+        val repository = HomeRepositoryImpl(
+            gourmetDao = FakeGourmetDao(listOf(testGourmet)),
+            collectionDao = FakeCollectionDao(insertResult = -1L),
+            temporaryAiComment = temporaryAiComment,
+        )
+
+        val result = repository.getRecommendation(moodText = moodText)
+
+        assertNotNull(result)
+        assertEquals(false, result?.isNewDiscovery)
+    }
+
+    @Test
+    fun getRecommendation_whenGourmetsAreEmpty_returnsNull() = runBlocking {
+        val collectionDao = FakeCollectionDao(insertResult = 1L)
+        val repository = HomeRepositoryImpl(
+            gourmetDao = FakeGourmetDao(emptyList()),
+            collectionDao = collectionDao,
+            temporaryAiComment = temporaryAiComment,
+        )
+
+        val result = repository.getRecommendation(moodText = moodText)
+
+        assertNull(result)
+        assertNull(collectionDao.insertedItem)
+    }
+
+    @Test
+    fun getRecommendation_savesSelectedGourmetWithMoodAndAiComment() = runBlocking {
+        val collectionDao = FakeCollectionDao(insertResult = 1L)
+        val repository = HomeRepositoryImpl(
+            gourmetDao = FakeGourmetDao(listOf(testGourmet)),
+            collectionDao = collectionDao,
+            temporaryAiComment = temporaryAiComment,
+        )
+
+        repository.getRecommendation(moodText = moodText)
+
+        val insertedItem = collectionDao.insertedItem
+        assertNotNull(insertedItem)
+        assertEquals(testGourmet.id, insertedItem?.gourmetId)
+        assertEquals(moodText, insertedItem?.moodText)
+        assertEquals(temporaryAiComment, insertedItem?.aiComment)
+    }
+
+    private class FakeGourmetDao(
+        private val gourmets: List<GourmetEntity>,
+    ) : GourmetDao {
+
+        override suspend fun insertAll(items: List<GourmetEntity>) = Unit
+
+        override suspend fun getById(id: Int): GourmetEntity? {
+            return gourmets.firstOrNull { gourmet -> gourmet.id == id }
+        }
+
+        override suspend fun getAll(): List<GourmetEntity> = gourmets
+
+        override suspend fun count(): Int = gourmets.size
+    }
+
+    private class FakeCollectionDao(
+        private val insertResult: Long,
+    ) : CollectionDao {
+
+        var insertedItem: GourmetCollectionEntity? = null
+            private set
+
+        override suspend fun insert(item: GourmetCollectionEntity): Long {
+            insertedItem = item
+            return insertResult
+        }
+
+        override fun getAllWithGourmet(): Flow<List<CollectionWithGourmetRow>> = emptyFlow()
+
+        override suspend fun getByGourmetId(gourmetId: Int): CollectionWithGourmetRow? = null
+
+        override suspend fun deleteByGourmetId(gourmetId: Int): Int = 0
+
+        override suspend fun updateFavoriteByGourmetId(gourmetId: Int, favorite: Boolean): Int = 0
+    }
+
+    private companion object {
+        const val moodText = "こってりしたものが食べたい"
+        const val temporaryAiComment = "仮の紹介文"
+
+        val testGourmet = GourmetEntity(
+            id = 1,
+            name = "焼きカレー",
+            area = "門司港",
+            category = "ごはん",
+            description = "香ばしく焼いたカレーです。",
+            searchKeyword = "北九州 焼きカレー",
+        )
+    }
+}


### PR DESCRIPTION
## 概要

- ホーム提案Repositoryで、選ばれたグルメを `gourmet_collection` に保存する処理を追加
- `CollectionDao.insert()` の戻り値から、新規発見か登録済みかを判定
- Repositoryの返却モデルに `isNewDiscovery` を追加
- Repository単体テストを追加

## 変更内容

- `HomeRepository.getRecommendation()` で `moodText` を受け取るように変更
- `HomeRepositoryImpl` に `CollectionDao` と仮AI紹介文を渡せるように変更
- `GourmetCollectionEntity` に `gourmetId` / `moodText` / `aiComment` を保存
- `OnConflictStrategy.IGNORE` の戻り値 `-1L` を登録済みとして扱う
- 仮AI紹介文を `strings.xml` に追加

## 確認

- [x] 初回登録時に `isNewDiscovery == true` になること
- [x] 重複登録時に `isNewDiscovery == false` になること
- [x] グルメ候補が空の場合に `null` を返すこと
- [x] 保存される `gourmetId` / `moodText` / `aiComment` が正しいこと
- [x] `./gradlew testDebugUnitTest`

## 関連Issue

Closes #63
