### PR TITLE
feat: HomeViewModelをRepository接続に変更する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/repository/HomeRepository.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/HomeRepository.kt
@@ -7,7 +7,8 @@ interface HomeRepository {
 data class HomeRecommendation(
     val id: Int,
     val name: String,
-    val description: String,
     val category: String,
+    val area: String,
+    val comment: String,
     val isNewDiscovery: Boolean,
 )

--- a/app/src/main/java/com/issy/meshigen/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/HomeRepositoryImpl.kt
@@ -39,8 +39,9 @@ class HomeRepositoryImpl(
         return HomeRecommendation(
             id = gourmet.id,
             name = gourmet.name,
-            description = gourmet.description,
             category = gourmet.category,
+            area = gourmet.area,
+            comment = temporaryAiComment,
             isNewDiscovery = isNewDiscovery,
         )
     }

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeDummyDataSource.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeDummyDataSource.kt
@@ -1,18 +1,14 @@
 package com.issy.meshigen.feature.home
 
 internal object HomeDummyDataSource {
-    fun createDummyRecommendations(): List<RecommendationUiModel> = listOf(
-        RecommendationUiModel(
-            id = "kokura_yaki_udon",
+    fun createDummyRecommendation(): RecommendationUiModel {
+        return RecommendationUiModel(
+            gourmetId = "1",
             name = "小倉焼うどん",
-            description = "香ばしくて満足感があり、ガッツリ食べたい気分に合います。",
-            category = "麺"
-        ),
-        RecommendationUiModel(
-            id = "yaki_curry",
-            name = "焼きカレー",
-            description = "熱々で濃厚なので、ちょっと元気を出したい時に向いています。",
-            category = "ご飯もの"
+            category = "麺",
+            area = "小倉",
+            comment = "香ばしくて満足感があり、ガッツリ食べたい気分に合います。",
+            isNewDiscovery = true,
         )
-    )
+    }
 }

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
@@ -1,14 +1,11 @@
 package com.issy.meshigen.feature.home
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
@@ -19,7 +16,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -27,10 +26,24 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.issy.meshigen.R
+import com.issy.meshigen.data.local.DatabaseProvider
+import com.issy.meshigen.data.repository.HomeRepositoryImpl
 
 @Composable
 internal fun HomeScreen() {
-    val homeViewModel: HomeViewModel = viewModel()
+    val context = LocalContext.current
+
+    val factory = remember(context) {
+        val db = DatabaseProvider.get(context)
+        val repository = HomeRepositoryImpl(
+            gourmetDao = db.gourmetDao(),
+            collectionDao = db.CollectionDao(),
+            temporaryAiComment = "仮の生成コメント", //TODO: AIコメント生成ロジックを実装
+        )
+        HomeViewModelFactory(repository)
+    }
+
+    val homeViewModel: HomeViewModel = viewModel(factory = factory)
     val uiState by homeViewModel.uiState.collectAsStateWithLifecycle()
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -119,24 +132,11 @@ fun HomeScreenContent(
                 }
 
                 is HomeRecommendationUiState.Success -> {
-                    RecommendationList(recs = uiState.recommendationUiState.items)
+                    RecommendationCard(
+                        item = uiState.recommendationUiState.recommendation,
+                    )
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun RecommendationList(
-    recs: List<RecommendationUiModel>,
-    modifier: Modifier = Modifier,
-) {
-    LazyColumn(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        items(recs, key = { it.id }){ item ->
-            RecommendationCard(item = item)
         }
     }
 }
@@ -160,14 +160,14 @@ private fun RecommendationCard(
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = item.description,
+                text = item.comment,
                 style = MaterialTheme.typography.bodyMedium,
             )
 
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = item.category,
+                text = "${item.category} / ${item.area}",
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
             )

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
@@ -32,7 +32,7 @@ private fun HomeScreenSuccessPreview() {
         HomeScreenContent(
             uiState = HomeUiState(
                 moodText = "甘い物",
-                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendation()),
             ),
             onEvent = {},
             modifier = Modifier,
@@ -62,7 +62,7 @@ private fun HomeScreenSuccessNarrowPreview() {
         HomeScreenContent(
             uiState = HomeUiState(
                 moodText = "甘い物",
-                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendation()),
             ),
             onEvent = {},
             modifier = Modifier,
@@ -92,7 +92,7 @@ private fun HomeScreenSuccessDarkModePreview() {
         HomeScreenContent(
             uiState = HomeUiState(
                 moodText = "甘い物",
-                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendations()),
+                recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendation()),
             ),
             onEvent = {},
             modifier = Modifier,

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeUiState.kt
@@ -6,15 +6,19 @@ data class HomeUiState(
 )
 
 data class RecommendationUiModel(
-    val id: String,
+    val gourmetId: String,
     val name: String,
-    val description: String,
     val category: String,
+    val area: String,
+    val comment: String,
+    val isNewDiscovery: Boolean,
 )
 
 sealed interface HomeRecommendationUiState {
     data object Initial : HomeRecommendationUiState
-    data class Success(val items: List<RecommendationUiModel>) : HomeRecommendationUiState
+    data class Success(
+        val recommendation: RecommendationUiModel,
+    ) : HomeRecommendationUiState
 }
 
 sealed interface HomeUiEvent {

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModel.kt
@@ -1,12 +1,18 @@
 package com.issy.meshigen.feature.home
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.issy.meshigen.data.repository.HomeRecommendation
+import com.issy.meshigen.data.repository.HomeRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-class HomeViewModel : ViewModel() {
+class HomeViewModel(
+    private val repository: HomeRepository,
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
@@ -25,15 +31,31 @@ class HomeViewModel : ViewModel() {
     }
 
     private fun recommendIfPossible() {
-        if (_uiState.value.moodText.isBlank()) {
+        val moodText = _uiState.value.moodText.trim()
+        if (moodText.isBlank()) {
             return
         }
 
-        val items = HomeDummyDataSource.createDummyRecommendations()
-        _uiState.update { currentState ->
-            currentState.copy(
-                recommendationUiState = HomeRecommendationUiState.Success(items)
-            )
+        viewModelScope.launch {
+            val recommendation = repository.getRecommendation(moodText) ?: return@launch
+            _uiState.update { currentState ->
+                currentState.copy(
+                    recommendationUiState = HomeRecommendationUiState.Success(
+                        recommendation = recommendation.toUiModel(),
+                    )
+                )
+            }
         }
+    }
+
+    private fun HomeRecommendation.toUiModel(): RecommendationUiModel {
+        return RecommendationUiModel(
+            gourmetId = id.toString(),
+            name = name,
+            category = category,
+            area = area,
+            comment = comment,
+            isNewDiscovery = isNewDiscovery,
+        )
     }
 }

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModelFactory.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.issy.meshigen.feature.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.issy.meshigen.data.repository.HomeRepository
+
+class HomeViewModelFactory(
+    private val repository: HomeRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(HomeViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return HomeViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/test/java/com/issy/meshigen/data/repository/HomeRepositoryImplTest.kt
+++ b/app/src/test/java/com/issy/meshigen/data/repository/HomeRepositoryImplTest.kt
@@ -44,6 +44,24 @@ class HomeRepositoryImplTest {
     }
 
     @Test
+    fun getRecommendation_returnsSelectedGourmetWithTemporaryComment() = runBlocking {
+        val repository = HomeRepositoryImpl(
+            gourmetDao = FakeGourmetDao(listOf(testGourmet)),
+            collectionDao = FakeCollectionDao(insertResult = 1L),
+            temporaryAiComment = temporaryAiComment,
+        )
+
+        val result = repository.getRecommendation(moodText = moodText)
+
+        assertNotNull(result)
+        assertEquals(testGourmet.id, result?.id)
+        assertEquals(testGourmet.name, result?.name)
+        assertEquals(testGourmet.category, result?.category)
+        assertEquals(testGourmet.area, result?.area)
+        assertEquals(temporaryAiComment, result?.comment)
+    }
+
+    @Test
     fun getRecommendation_whenGourmetsAreEmpty_returnsNull() = runBlocking {
         val collectionDao = FakeCollectionDao(insertResult = 1L)
         val repository = HomeRepositoryImpl(


### PR DESCRIPTION
## 概要

- HomeViewModel が HomeRepository を受け取る構成に変更
- おすすめボタン押下時に Repository の提案結果を取得し、HomeUiState に反映
- ホーム提案UIを1件表示向けに整理
- Repository の返却内容に area / comment を追加し、テストで確認

## 背景

HomeViewModel が HomeDummyDataSource を直接呼び出していたため、Room 経由の提案結果を画面へ接続できるよう Repository 経由の構成に変更しました。

## 確認

- [x] ./gradlew testDebugUnitTest

Closes #64
