### PR TITLE
feat: ホーム提案カードに発見状態を表示

### DIFF
--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
@@ -152,6 +152,20 @@ private fun RecommendationCard(
         Column (
             modifier = Modifier.padding(16.dp),
         ) {
+            val discoveryText = if (item.isNewDiscovery) {
+                stringResource(R.string.home_recommendation_new_discovery)
+            } else {
+                stringResource(R.string.home_recommendation_already_discovered)
+            }
+
+            Text(
+                text = discoveryText,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
             Text(
                 text = item.name,
                 style = MaterialTheme.typography.titleMedium,
@@ -167,10 +181,32 @@ private fun RecommendationCard(
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = "${item.category} / ${item.area}",
+                text = stringResource(
+                    R.string.home_recommendation_category_area,
+                    item.category,
+                    item.area,
+                ),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
             )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.home_action_search_maps))
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Button(
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.home_action_view_collection))
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,11 @@
     <string name="home_recommend_button">おすすめを見る</string>
     <string name="home_initial_hint">気分を入力すると、おすすめ結果がここに表示されます。</string>
     <string name="home_temporary_ai_comment">あなたの気分にぴったりのグルメを見つけました！</string>
+    <string name="home_recommendation_new_discovery">新しいグルメを発見しました！</string>
+    <string name="home_recommendation_already_discovered">図鑑登録済み</string>
+    <string name="home_recommendation_category_area">%1$s / %2$s</string>
+    <string name="home_action_search_maps">Google Mapsで探す</string>
+    <string name="home_action_view_collection">図鑑で見る</string>
 
     <string name="collection_list_title">図鑑一覧</string>
     <string name="collection_list_description">保存した北九州B級グルメを確認できます。</string>


### PR DESCRIPTION
## 概要

- ホーム提案カードに初回発見/図鑑登録済みの状態表示を追加
- カテゴリ/エリア表示を `strings.xml` 経由に変更
- 「Google Mapsで探す」「図鑑で見る」ボタンを見た目だけ追加

## 対応Issue

Closes #65

## 確認したこと

- Issue #65 のチェック項目をすべて満たしていることを確認
- `./gradlew testDebugUnitTest` が成功

## やっていないこと

- 詳細画面への遷移処理
- Google Maps の実処理
- AI連携
