### PR TITLE
feat: ホーム提案から詳細画面へ遷移できるようにする

### DIFF
--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreen.kt
@@ -30,7 +30,9 @@ import com.issy.meshigen.data.local.DatabaseProvider
 import com.issy.meshigen.data.repository.HomeRepositoryImpl
 
 @Composable
-internal fun HomeScreen() {
+internal fun HomeScreen(
+    onOpenDetailClick: (String) -> Unit,
+) {
     val context = LocalContext.current
 
     val factory = remember(context) {
@@ -50,6 +52,7 @@ internal fun HomeScreen() {
     HomeScreenContent(
         uiState = uiState,
         onEvent = homeViewModel::onEvent,
+        onOpenDetailClick = onOpenDetailClick,
         onKeyboardDismissRequest = { keyboardController?.hide() },
     )
 }
@@ -58,6 +61,7 @@ internal fun HomeScreen() {
 fun HomeScreenContent(
     uiState: HomeUiState,
     onEvent: (HomeUiEvent) -> Unit,
+    onOpenDetailClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     onKeyboardDismissRequest: () -> Unit = { },
 ) {
@@ -134,6 +138,7 @@ fun HomeScreenContent(
                 is HomeRecommendationUiState.Success -> {
                     RecommendationCard(
                         item = uiState.recommendationUiState.recommendation,
+                        onOpenDetailClick = onOpenDetailClick,
                     )
                 }
             }
@@ -144,6 +149,7 @@ fun HomeScreenContent(
 @Composable
 private fun RecommendationCard(
     item: RecommendationUiModel,
+    onOpenDetailClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -202,7 +208,7 @@ private fun RecommendationCard(
             Spacer(modifier = Modifier.height(8.dp))
 
             Button(
-                onClick = {},
+                onClick = { onOpenDetailClick(item.gourmetId) },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.home_action_view_collection))

--- a/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/home/HomeScreenPreview.kt
@@ -20,6 +20,7 @@ private fun HomeScreenInitialPreview() {
                 recommendationUiState = HomeRecommendationUiState.Initial,
             ),
             onEvent = {},
+            onOpenDetailClick = {},
             modifier = Modifier,
         )
     }
@@ -35,6 +36,7 @@ private fun HomeScreenSuccessPreview() {
                 recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendation()),
             ),
             onEvent = {},
+            onOpenDetailClick = {},
             modifier = Modifier,
         )
     }
@@ -50,6 +52,7 @@ private fun HomeScreenInitialNarrowPreview() {
                 recommendationUiState = HomeRecommendationUiState.Initial,
             ),
             onEvent = {},
+            onOpenDetailClick = {},
             modifier = Modifier,
         )
     }
@@ -65,6 +68,7 @@ private fun HomeScreenSuccessNarrowPreview() {
                 recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendation()),
             ),
             onEvent = {},
+            onOpenDetailClick = {},
             modifier = Modifier,
         )
     }
@@ -80,6 +84,7 @@ private fun HomeScreenInitialDarkModePreview() {
                 recommendationUiState = HomeRecommendationUiState.Initial,
             ),
             onEvent = {},
+            onOpenDetailClick = {},
             modifier = Modifier,
         )
     }
@@ -95,6 +100,7 @@ private fun HomeScreenSuccessDarkModePreview() {
                 recommendationUiState = HomeRecommendationUiState.Success(HomeDummyDataSource.createDummyRecommendation()),
             ),
             onEvent = {},
+            onOpenDetailClick = {},
             modifier = Modifier,
         )
     }

--- a/app/src/main/java/com/issy/meshigen/navigation/MeshigenNavHost.kt
+++ b/app/src/main/java/com/issy/meshigen/navigation/MeshigenNavHost.kt
@@ -22,7 +22,13 @@ internal fun MeshigenNavHost(
         modifier = modifier,
     ) {
         composable(route = MeshigenDestination.HOME_ROUTE) {
-            HomeScreen()
+            HomeScreen(
+                onOpenDetailClick = { gourmetId ->
+                    navController.navigate(
+                        MeshigenDestination.createDetailRoute(gourmetId)
+                    )
+                },
+            )
         }
         composable(route = MeshigenDestination.COLLECTION_ROUTE) {
             CollectionListScreen(


### PR DESCRIPTION
## 概要

- ホーム提案カードの「図鑑で見る」から図鑑詳細へ遷移できるようにしました
- `HomeScreen` には `NavController` を渡さず、遷移用callbackだけを渡す構成にしました
- Preview 側にも `onOpenDetailClick` の空実装を追加しました

## 関連Issue

Closes #66

## 変更内容

- `HomeScreen` / `HomeScreenContent` に `onOpenDetailClick: (String) -> Unit` を追加
- `RecommendationCard` の「図鑑で見る」押下時に `item.gourmetId` をcallbackへ渡すように変更
- `MeshigenNavHost` で `MeshigenDestination.createDetailRoute(gourmetId)` を使って詳細画面へnavigateするように変更

## 確認したこと

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] 画面上で対象操作を確認

## 学習・設計メモ

- 画面遷移の具体処理は `MeshigenNavHost` に置き、ホーム画面側は「この `gourmetId` の詳細を開きたい」というUIイベントだけをcallbackで通知する形にしました
- `HomeScreen` に `NavController` を直接渡さないことで、UIとNavigationの責務を分けています

## やらないこと

- Google Maps連携
- 未発見ロック詳細
- 図鑑一覧の全30枠表示
- AI連携
