### PR TITLE
feat: 図鑑一覧のデータ基盤を全30件+発見状態対応にする

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
 import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -35,6 +36,32 @@ interface CollectionDao {
         """
     )
     fun getAllWithGourmet(): Flow<List<CollectionWithGourmetRow>>
+
+    // gourmets基準で全件取得(未発見を含む)
+    @Query(
+        """
+            SELECT
+                g.id AS gourmet_id,
+                g.name,
+                g.area,
+                g.category,
+                g.description,
+                g.search_keyword,
+                (gc.id IS NOT NULL) AS discovered,
+                gc.id AS collection_id,
+                gc.mood_text,
+                gc.ai_comment,
+                COALESCE(gc.is_favorite, 0) AS is_favorite,
+                gc.created_at
+            FROM gourmets AS g
+            LEFT JOIN gourmet_collection AS gc ON gc.gourmet_id = g.id
+            ORDER BY
+                (gc.id IS NULL) ASC,
+                gc.created_at DESC,
+                g.id ASC
+        """
+    )
+    fun observeAllGourmetsWithDiscovery(): Flow<List<GourmetWithDiscoveryRow>>
 
     // コレクションIDで取得
     @Query(

--- a/app/src/main/java/com/issy/meshigen/data/local/query/GourmetWithDiscoveryRow.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/query/GourmetWithDiscoveryRow.kt
@@ -1,0 +1,25 @@
+package com.issy.meshigen.data.local.query
+
+import androidx.room.ColumnInfo
+
+data class GourmetWithDiscoveryRow(
+    @ColumnInfo(name = "gourmet_id")
+    val gourmetId: Int,
+    val name: String,
+    val area: String,
+    val category: String,
+    val description: String,
+    @ColumnInfo(name = "search_keyword")
+    val searchKeyword: String,
+    val discovered: Boolean,
+    @ColumnInfo(name = "collection_id")
+    val collectionId: Int?,
+    @ColumnInfo(name = "mood_text")
+    val moodText: String?,
+    @ColumnInfo(name = "ai_comment")
+    val aiComment: String?,
+    @ColumnInfo(name = "is_favorite")
+    val favorite: Boolean,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long?,
+)

--- a/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepository.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepository.kt
@@ -1,9 +1,9 @@
 package com.issy.meshigen.data.repository
 
-import com.issy.meshigen.feature.collection.CollectionListUiModel
+import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
 import kotlinx.coroutines.flow.Flow
 
 interface CollectionRepository {
-    fun observeCollections(): Flow<List<CollectionListUiModel>>
+    fun observeAllGourmetsWithDiscovery(): Flow<List<GourmetWithDiscoveryRow>>
     suspend fun updateFavorite(gourmetId: Int, favorite: Boolean)
 }

--- a/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepositoryImpl.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/CollectionRepositoryImpl.kt
@@ -1,38 +1,18 @@
 package com.issy.meshigen.data.repository
 
 import com.issy.meshigen.data.local.dao.CollectionDao
-import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
-import com.issy.meshigen.feature.collection.CollectionListUiModel
+import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import java.time.Instant
-import java.time.ZoneId
 
 class CollectionRepositoryImpl(
     private val collectionDao: CollectionDao
 ): CollectionRepository {
 
-    override fun observeCollections(): Flow<List<CollectionListUiModel>> {
-        return collectionDao.getAllWithGourmet()
-            .map { rows -> rows.map(::toUiModel) }
+    override fun observeAllGourmetsWithDiscovery(): Flow<List<GourmetWithDiscoveryRow>> {
+        return collectionDao.observeAllGourmetsWithDiscovery()
     }
 
     override suspend fun updateFavorite(gourmetId: Int, favorite: Boolean) {
         collectionDao.updateFavoriteByGourmetId(gourmetId, favorite)
-    }
-
-    private fun toUiModel(row: CollectionWithGourmetRow): CollectionListUiModel {
-        return CollectionListUiModel(
-            collectionId = row.collectionId.toString(),
-            gourmetId = row.gourmetId.toString(),
-            name = row.name,
-            category = row.category,
-            area = row.area,
-            suggestedDate = Instant.ofEpochMilli(row.createdAt)
-                .atZone(ZoneId.systemDefault())
-                .toLocalDate()
-                .toString(),
-            favorite = row.favorite,
-        )
     }
 }

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
@@ -2,12 +2,15 @@ package com.issy.meshigen.feature.collection
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
 import com.issy.meshigen.data.repository.CollectionRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
 
 data class CollectionListUiState(
     val items: List<CollectionListUiModel> = emptyList(),
@@ -18,8 +21,8 @@ class CollectionListViewModel(
 ) : ViewModel() {
 
     val uiState: StateFlow<CollectionListUiState> =
-        repository.observeCollections()
-            .map { items -> CollectionListUiState(items = items) }
+        repository.observeAllGourmetsWithDiscovery()
+            .map { rows -> CollectionListUiState(items = rows.map(::toUiModel)) }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5_000),
@@ -31,5 +34,22 @@ class CollectionListViewModel(
         viewModelScope.launch {
             repository.updateFavorite(gourmetId, !item.favorite)
         }
+    }
+
+    private fun toUiModel(row: GourmetWithDiscoveryRow): CollectionListUiModel {
+        return CollectionListUiModel(
+            collectionId = row.collectionId?.toString() ?: "",
+            gourmetId = row.gourmetId.toString(),
+            name = row.name,
+            category = row.category,
+            area = row.area,
+            suggestedDate = row.createdAt
+                ?.let { Instant.ofEpochMilli(it)
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDate()
+                    .toString() }
+            ?: "",
+            favorite = row.favorite,
+        )
     }
 }


### PR DESCRIPTION
## 関連 Issue
closes #57

## 概要
- `gourmets LEFT JOIN gourmet_collection` クエリを追加し、未発見を含む全30件をデータ層で扱えるようにした
- 発見状態を `discovered: Boolean` として判定できる `GourmetWithDiscoveryRow` DTO を新規追加
- `CollectionRepository` 契約をデータ層の型を返す形へ更新（UI層の型をデータ層から排除）
- `CollectionListViewModel` で `GourmetWithDiscoveryRow` → `CollectionListUiModel` への変換を担うよう変更

## 変更ファイル
- `data/local/query/GourmetWithDiscoveryRow.kt`（新規）
- `data/local/dao/CollectionDao.kt`：`observeAllGourmetsWithDiscovery()` 追加
- `data/repository/CollectionRepository.kt`：契約を `GourmetWithDiscoveryRow` 返却に更新
- `data/repository/CollectionRepositoryImpl.kt`：新契約に合わせて実装を更新
- `feature/collection/CollectionListViewModel.kt`：データ層→UI層の変換を ViewModel に移動

## 設計メモ
- `collectionId` はDB内部キーとしてのみ扱い、画面導線の主IDは `gourmetId` に統一
- 未発見アイテムの UI 表示（`???`）は後続 #58 で対応
- `COALESCE(gc.is_favorite, 0)` により未発見時の `favorite` を non-null で扱える

## 動作確認
- [x] `./gradlew :app:compileDebugKotlin` 成功