### PR TITLE
feat: 図鑑一覧に???表示・発見数・4フィルタを実装する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreen.kt
@@ -43,6 +43,7 @@ data class CollectionListUiModel(
     val category: String,
     val area: String,
     val suggestedDate: String, // yyyy-MM-dd
+    val discovered: Boolean,
     val favorite: Boolean,
 )
 
@@ -56,39 +57,45 @@ data class CollectionFilterUiModel(
 internal fun CollectionListScreen(
     onItemClick: (String) -> Unit,
 ) {
-    val filters = listOf(
-        CollectionFilterUiModel(
-            id = "all",
-            label = stringResource(R.string.collection_filter_all),
-            selected = true,
-        ),
-        CollectionFilterUiModel(
-            id = "noodle",
-            label = stringResource(R.string.collection_filter_noodle),
-            selected = false,
-        ),
-        CollectionFilterUiModel(
-            id = "rice",
-            label = stringResource(R.string.collection_filter_rice),
-            selected = false,
-        ),
-    )
 
     val context = LocalContext.current
-
     val factory = remember(context) {
         val db = DatabaseProvider.get(context)
         val repository = CollectionRepositoryImpl(db.CollectionDao())
         CollectionListViewModelFactory(repository)
     }
-
     val collectionListViewModel: CollectionListViewModel = viewModel(factory = factory)
+
     val uiState by collectionListViewModel.uiState.collectAsStateWithLifecycle()
+
+    val filters = listOf(
+        CollectionFilterUiModel(
+            id = "all",
+            label = stringResource(R.string.collection_filter_all),
+            selected = uiState.selectedFilter == "all",
+        ),
+        CollectionFilterUiModel(
+            id = "undiscovered",
+            label = stringResource(R.string.collection_filter_undiscovered),
+            selected = uiState.selectedFilter == "undiscovered",
+        ),
+        CollectionFilterUiModel(
+            id = "discovered",
+            label = stringResource(R.string.collection_filter_discovered),
+            selected = uiState.selectedFilter == "discovered",
+        ),
+        CollectionFilterUiModel(
+            id = "favorite",
+            label = stringResource(R.string.collection_filter_favorite),
+            selected = uiState.selectedFilter == "favorite",
+        ),
+    )
 
     CollectionListScreenContent(
         filters = filters,
         items = uiState.items,
-        onFilterClick = {},
+        discoveredCount = uiState.discoveredCount,
+        onFilterClick = { collectionListViewModel.onFilterClick(it.id) },
         onItemClick = { item -> onItemClick(item.gourmetId) },
         onFavoriteClick = collectionListViewModel::onFavoriteClick,
     )
@@ -98,6 +105,7 @@ internal fun CollectionListScreen(
 internal fun CollectionListScreenContent(
     filters: List<CollectionFilterUiModel>,
     items: List<CollectionListUiModel>,
+    discoveredCount: Int,
     onFilterClick: (CollectionFilterUiModel) -> Unit,
     onItemClick: (CollectionListUiModel) -> Unit,
     onFavoriteClick: (CollectionListUiModel) -> Unit,
@@ -126,6 +134,13 @@ internal fun CollectionListScreenContent(
 
             Spacer(modifier = Modifier.height(8.dp))
 
+            Text(
+                text = stringResource(R.string.collection_list_discovery_count, discoveredCount),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
             FilterRow(
                 filters = filters,
                 onFilterClick = onFilterClick,
@@ -142,7 +157,7 @@ internal fun CollectionListScreenContent(
                     modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(items = items, key = { it.collectionId }) { item ->
+                    items(items = items, key = { it.gourmetId }) { item ->
                         CollectionListCard(
                             item = item,
                             onClick = { onItemClick(item) },
@@ -195,29 +210,33 @@ private  fun CollectionListCard(
         ) {
             Column(modifier.weight(1f)) {
                 Text(
-                    text = item.name,
+                    text = if (item.discovered) item.name else "???",
                     style = MaterialTheme.typography.titleMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
                 Text(
-                    text = "${item.category}/${item.area}",
+                    text = if (item.discovered) "${item.category}/${item.area}" else "???",
                     style = MaterialTheme.typography.bodyMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                Text(
-                    text = item.suggestedDate,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                if (item.discovered) {
+                    Text(
+                        text = item.suggestedDate,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
 
-            FavoriteIcon(
-                favorite = item.favorite,
-                onClick = onFavoriteClick,
-            )
+            if (item.discovered) {
+                FavoriteIcon(
+                    favorite = item.favorite,
+                    onClick = onFavoriteClick,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreenPreview.kt
@@ -6,8 +6,26 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.issy.meshigen.ui.theme.MeshigenTheme
 
 private val previewFilters = listOf(
-    CollectionFilterUiModel(id = "all", label = "すべて", selected = true),
-    CollectionFilterUiModel(id = "noodle", label = "麺", selected = false),
+    CollectionFilterUiModel(
+        id = "all",
+        label = "すべて",
+        selected = true,
+    ),
+    CollectionFilterUiModel(
+        id = "undiscovered",
+        label = "未発見",
+        selected = false,
+    ),
+    CollectionFilterUiModel(
+        id = "discovered",
+        label = "発見済み",
+        selected = false,
+    ),
+    CollectionFilterUiModel(
+        id = "favorite",
+        label = "お気に入り",
+        selected = false,
+    ),
 )
 
 private val previewItems = listOf(
@@ -18,7 +36,8 @@ private val previewItems = listOf(
         category = "麺",
         area = "小倉北区",
         suggestedDate = "2026-04-09", // yyyy-MM-dd
-        favorite = false,
+        discovered = false,
+        favorite = true,
     )
 )
 
@@ -30,7 +49,8 @@ private val previewItemsLongState = listOf(
         category = "麺料理と鉄板グルメの合わせ技",
         area = "小倉北区魚町銀天街アーケード沿いの老舗エリア",
         suggestedDate = "2026-04-09", // yyyy-MM-dd
-        favorite = false,
+        discovered = true,
+        favorite = true,
     )
 )
 
@@ -41,6 +61,7 @@ private fun CollectionListScreenPreview() {
         CollectionListScreenContent(
             filters = previewFilters,
             items = previewItemsLongState,
+            discoveredCount = 1,
             onFilterClick = {},
             onItemClick = {},
             onFavoriteClick = {},
@@ -55,6 +76,7 @@ private fun CollectionEmptyListScreenPreview() {
         CollectionListScreenContent(
             filters = previewFilters,
             items = emptyList(),
+            discoveredCount = 1,
             onFilterClick = {},
             onItemClick = {},
             onFavoriteClick = {},
@@ -69,6 +91,7 @@ private fun CollectionNarrowListScreenPreview() {
         CollectionListScreenContent(
             filters = previewFilters,
             items = previewItems,
+            discoveredCount = 1,
             onFilterClick = {},
             onItemClick = {},
             onFavoriteClick = {},
@@ -83,6 +106,7 @@ private fun CollectionDarkListScreenPreview() {
         CollectionListScreenContent(
             filters = previewFilters,
             items = previewItems,
+            discoveredCount = 1,
             onFilterClick = {},
             onItemClick = {},
             onFavoriteClick = {},

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
 import com.issy.meshigen.data.repository.CollectionRepository
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -14,26 +16,49 @@ import java.time.ZoneId
 
 data class CollectionListUiState(
     val items: List<CollectionListUiModel> = emptyList(),
+    val selectedFilter: String = "all",
+    val discoveredCount: Int = 0,
 )
 
 class CollectionListViewModel(
     private val repository: CollectionRepository,
 ) : ViewModel() {
 
+    private val _selectedFilter = MutableStateFlow("all")
+
     val uiState: StateFlow<CollectionListUiState> =
-        repository.observeAllGourmetsWithDiscovery()
-            .map { rows -> CollectionListUiState(items = rows.map(::toUiModel)) }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5_000),
-                initialValue = CollectionListUiState(),
+        combine(
+            repository.observeAllGourmetsWithDiscovery(),
+            _selectedFilter,
+        ) { rows, filter ->
+            val allItems = rows.map(::toUiModel)
+            val filteredItems = when (filter) {
+                "undiscovered" -> allItems.filter { !it.discovered }
+                "discovered" -> allItems.filter { it.discovered }
+                "favorite" -> allItems.filter { it.discovered && it.favorite }
+                else -> allItems
+            }
+            CollectionListUiState(
+                items = filteredItems,
+                selectedFilter = filter,
+                discoveredCount = allItems.count { it.discovered }
             )
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = CollectionListUiState(),
+        )
 
     fun onFavoriteClick(item: CollectionListUiModel) {
         val gourmetId = item.gourmetId.toIntOrNull() ?: return
         viewModelScope.launch {
             repository.updateFavorite(gourmetId, !item.favorite)
         }
+    }
+
+    fun onFilterClick(filterId: String) {
+        _selectedFilter.value = filterId
     }
 
     private fun toUiModel(row: GourmetWithDiscoveryRow): CollectionListUiModel {
@@ -49,6 +74,7 @@ class CollectionListViewModel(
                     .toLocalDate()
                     .toString() }
             ?: "",
+            discovered = row.discovered,
             favorite = row.favorite,
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
     <string name="collection_filter_all">すべて</string>
     <string name="collection_filter_noodle">麺</string>
     <string name="collection_filter_rice">ごはん</string>
+    <string name="collection_filter_undiscovered">未発見</string>
+    <string name="collection_filter_discovered">発見済み</string>
+    <string name="collection_filter_favorite">お気に入り</string>
+    <string name="collection_list_discovery_count">%1$d / 30</string>
     <string name="collection_favorite_add">お気に入り登録</string>
     <string name="collection_favorite_remove">お気に入り解除</string>
 


### PR DESCRIPTION
## 概要

- 未発見カードを `???` 固定表示にし、名前・カテゴリ・エリアのヒントを出さない
- 発見数 / 30 をヘッダーに表示する
- フィルタを「全て / 未発見 / 発見済み / お気に入り」の4種に変更する
- ViewModel で `MutableStateFlow` + `combine` によるフィルタ状態管理と絞り込みを実装する
- 未発見アイテムのお気に入りボタンを非表示にする

## 関連 Issue

Closes #58

## テスト項目

- [x] 図鑑一覧で未発見アイテムが `???` 表示になる
- [x] 発見数 / 30 がヘッダーに表示される
- [x] 4フィルタが正しく動作する（全て / 未発見 / 発見済み / お気に入り）
- [x] 未発見アイテムのお気に入りボタンが非表示になる
- [x] 未発見カードをタップすると詳細へ遷移できる
- [x] `./gradlew :app:compileDebugKotlin` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)