### PR TITLE
feat: 図鑑詳細に未発見ロック状態を実装する (#60)

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
+++ b/app/src/main/java/com/issy/meshigen/data/local/dao/CollectionDao.kt
@@ -105,4 +105,14 @@ interface CollectionDao {
         """
     )
     suspend fun updateFavoriteByGourmetId(gourmetId: Int, favorite: Boolean): Int
+
+    // 件数が1件以上あるかを確認
+    @Query(
+        """
+            SELECT COUNT(*) > 0
+            FROM gourmets
+            WHERE id = :gourmetId
+        """
+    )
+    suspend fun existsGourmet(gourmetId: Int): Boolean
 }

--- a/app/src/main/java/com/issy/meshigen/data/repository/DetailRepository.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/DetailRepository.kt
@@ -6,4 +6,5 @@ interface DetailRepository {
     suspend fun getByGourmetId(gourmetId: Int): CollectionWithGourmetRow?
     suspend fun updateFavoriteByGourmetId(gourmetId: Int, favorite: Boolean): Boolean
     suspend fun deleteByGourmetId(gourmetId: Int): Boolean
+    suspend fun existsGourmet(gourmetId: Int): Boolean
 }

--- a/app/src/main/java/com/issy/meshigen/data/repository/DetailRepositoryImpl.kt
+++ b/app/src/main/java/com/issy/meshigen/data/repository/DetailRepositoryImpl.kt
@@ -14,4 +14,7 @@ class DetailRepositoryImpl(
 
     override suspend fun deleteByGourmetId(gourmetId: Int): Boolean =
         collectionDao.deleteByGourmetId(gourmetId) > 0
+
+    override suspend fun existsGourmet(gourmetId: Int): Boolean =
+        collectionDao.existsGourmet(gourmetId)
 }

--- a/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreen.kt
@@ -73,6 +73,7 @@ internal fun DetailScreen(
     when (val state = uiState) {
         DetailUiState.Loading -> LoadingContent()
         DetailUiState.NotFound -> NotFoundContent(onBackClick)
+        DetailUiState.Locked -> LockedContent(onBackClick)
         is DetailUiState.Ready -> DetailScreenContent(
             uiModel = state.item,
             onBackClick = onBackClick,
@@ -101,6 +102,33 @@ private fun LoadingContent(
                 text = stringResource(R.string.detail_loading),
                 style = MaterialTheme.typography.bodyMedium,
             )
+        }
+    }
+}
+
+@Composable
+private fun LockedContent(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.detail_locked),
+                style = MaterialTheme.typography.headlineLarge,
+            )
+            TextButton(onClick = onBackClick) {
+                Text(text = stringResource(R.string.detail_back))
+            }
         }
     }
 }

--- a/app/src/main/java/com/issy/meshigen/feature/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/detail/DetailViewModel.kt
@@ -12,6 +12,7 @@ sealed interface DetailUiState {
     data object Loading : DetailUiState
     data class Ready(val item: DetailUiModel) : DetailUiState
     data object NotFound : DetailUiState
+    data object Locked : DetailUiState
 }
 
 class DetailViewModel(
@@ -39,9 +40,14 @@ class DetailViewModel(
 
             val row = repository.getByGourmetId(id)
             if (row == null) {
-                _uiState.value = DetailUiState.NotFound
-                currentGourmetId = null
-                return@launch
+                if (repository.existsGourmet(id)) {
+                    _uiState.value = DetailUiState.Locked
+                    return@launch
+                } else {
+                    _uiState.value = DetailUiState.NotFound
+                    currentGourmetId = null
+                    return@launch
+                }
             }
 
             _uiState.value = DetailUiState.Ready(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,5 @@
     <string name="detail_action_delete">図鑑から削除</string>
     <string name="detail_loading">読み込み中…</string>
     <string name="detail_not_found">見つかりません</string>
+    <string name="detail_locked">\???</string>
 </resources>


### PR DESCRIPTION
## Summary
- `DetailUiState` に `Locked` を追加し、未発見と存在しないIDを明確に分離
- `CollectionDao` に `existsGourmet()` を追加し、gourmetsテーブルの存在確認を可能にした
- 未発見グルメの詳細遷移でヒントなし `???` のロック UI を表示する
- 発見済みグルメの既存機能（お気に入り・削除・Maps）は維持

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` が成功する
- [x] 未発見グルメから詳細遷移するとロック表示（`???`）になる
- [x] 存在しない gourmetId でアクセスすると NotFound になる
- [x] 発見済みグルメの詳細操作（お気に入り・削除）が正常に動作する

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)