### PR TITLE
test: 発見型図鑑(v1.5.0) の回帰テストとPreview補強 (#61)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/collection/CollectionListScreenPreview.kt
@@ -38,7 +38,7 @@ private val previewItems = listOf(
         suggestedDate = "2026-04-09", // yyyy-MM-dd
         discovered = false,
         favorite = true,
-    )
+    ),
 )
 
 private val previewItemsLongState = listOf(
@@ -52,6 +52,75 @@ private val previewItemsLongState = listOf(
         discovered = true,
         favorite = true,
     )
+)
+
+// すべて未発見
+private val previewItemsAllUndiscovered = listOf(
+    CollectionListUiModel(
+        gourmetId = "kokura-yakiudon",
+        collectionId = "1",
+        name = "小倉焼うどん",
+        category = "麺",
+        area = "小倉北区",
+        suggestedDate = "2026-04-09", // yyyy-MM-dd
+        discovered = false,
+        favorite = true,
+    ),
+    CollectionListUiModel(
+        gourmetId = "mojiko-yakiudon",
+        collectionId = "2",
+        name = "門司港焼うどん",
+        category = "麺",
+        area = "門司区レトロ地区の海沿いエリア",
+        suggestedDate = "2026-04-10", // yyyy-MM-dd
+        discovered = false,
+        favorite = false,
+    ),
+    CollectionListUiModel(
+        gourmetId = "wakamatu-gyoza",
+        collectionId = "3",
+        name = "若松ぎょうざ",
+        category = "中華",
+        area = "若松区",
+        suggestedDate = "2026-04-11", // yyyy-MM-dd
+        discovered = false,
+        favorite = false,
+
+    ),
+)
+
+// すべて発見済み
+private val previewItemsAllDiscovered = listOf(
+    CollectionListUiModel(
+        gourmetId = "kokura-yakiudon",
+        collectionId = "1",
+        name = "小倉焼うどん",
+        category = "麺",
+        area = "小倉北区",
+        suggestedDate = "2026-04-09", // yyyy-MM-dd
+        discovered = true,
+        favorite = true,
+    ),
+    CollectionListUiModel(
+        gourmetId = "mojiko-yakiudon",
+        collectionId = "2",
+        name = "門司港焼うどん",
+        category = "麺",
+        area = "門司区レトロ地区の海沿いエリア",
+        suggestedDate = "2026-04-10", // yyyy-MM-dd
+        discovered = true,
+        favorite = false,
+    ),
+    CollectionListUiModel(
+        gourmetId = "wakamatu-gyoza",
+        collectionId = "3",
+        name = "若松ぎょうざ",
+        category = "中華",
+        area = "若松区",
+        suggestedDate = "2026-04-11", // yyyy-MM-dd
+        discovered = true,
+        favorite = false,
+    ),
 )
 
 @Preview(name = "Collection Normal", showBackground = true)
@@ -107,6 +176,36 @@ private fun CollectionDarkListScreenPreview() {
             filters = previewFilters,
             items = previewItems,
             discoveredCount = 1,
+            onFilterClick = {},
+            onItemClick = {},
+            onFavoriteClick = {},
+        )
+    }
+}
+
+@Preview(name = "Collection All Undiscovered", showBackground = true)
+@Composable
+private fun CollectionAllUndiscoveredPreview() {
+    MeshigenTheme {
+        CollectionListScreenContent(
+            filters = previewFilters,
+            items = previewItemsAllUndiscovered,
+            discoveredCount = 0,
+            onFilterClick = {},
+            onItemClick = {},
+            onFavoriteClick = {},
+        )
+    }
+}
+
+@Preview(name = "Collection All Discovered", showBackground = true)
+@Composable
+private fun CollectionAllDiscoveredPreview() {
+    MeshigenTheme {
+        CollectionListScreenContent(
+            filters = previewFilters,
+            items = previewItemsAllDiscovered,
+            discoveredCount = 3,
             onFilterClick = {},
             onItemClick = {},
             onFavoriteClick = {},

--- a/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreen.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreen.kt
@@ -84,7 +84,7 @@ internal fun DetailScreen(
     }
 }
 @Composable
-private fun LoadingContent(
+internal fun LoadingContent(
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -107,7 +107,7 @@ private fun LoadingContent(
 }
 
 @Composable
-private fun LockedContent(
+internal fun LockedContent(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -134,7 +134,7 @@ private fun LockedContent(
 }
 
 @Composable
-private fun NotFoundContent(
+internal fun NotFoundContent(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreenPreview.kt
+++ b/app/src/main/java/com/issy/meshigen/feature/detail/DetailScreenPreview.kt
@@ -82,3 +82,41 @@ private fun DetailScreenDarkPreview() {
         )
     }
 }
+
+@Preview(name = "Detail Locked", showBackground = true)
+@Composable
+private fun DetailScreenLockedPreview() {
+    MeshigenTheme {
+        LockedContent(
+            onBackClick = {},
+        )
+    }
+}
+
+@Preview(name = "Detail Locked Dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+private fun DetailScreenLockedDarkPreview() {
+    MeshigenTheme {
+        LockedContent(
+            onBackClick = {},
+        )
+    }
+}
+
+@Preview(name = "Detail NotFound", showBackground = true)
+@Composable
+private fun DetailScreenNotFoundPreview() {
+    MeshigenTheme {
+        NotFoundContent(
+            onBackClick = {},
+        )
+    }
+}
+
+@Preview(name = "Detail Loading", showBackground = true)
+@Composable
+private fun DetailScreenLoadingPreview() {
+    MeshigenTheme {
+        LoadingContent()
+    }
+}

--- a/app/src/test/java/com/issy/meshigen/data/repository/CollectionRepositoryImplTest.kt
+++ b/app/src/test/java/com/issy/meshigen/data/repository/CollectionRepositoryImplTest.kt
@@ -1,0 +1,121 @@
+package com.issy.meshigen.data.repository
+
+import com.issy.meshigen.data.local.dao.CollectionDao
+import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
+import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CollectionRepositoryImplTest {
+
+    @Test
+    fun observeAllGourmetsWithDiscovery_returnsAll30RowsFromDao() = runBlocking {
+        val rows = List(30) { index -> buildRow(gourmetId = index + 1) }
+        val repository = CollectionRepositoryImpl(
+            collectionDao = FakeCollectionDao(rowsToEmit = rows)
+        )
+
+        val result = repository.observeAllGourmetsWithDiscovery().first()
+
+        assertEquals(30, result.size)
+    }
+
+    @Test
+    fun observeAllGourmetsWithDiscovery_passesThroughDiscoveredRow() = runBlocking {
+        val discoveredRow = buildRow(gourmetId = 1, discovered = true, favorite = true)
+        val repository = CollectionRepositoryImpl(
+            collectionDao = FakeCollectionDao(rowsToEmit = listOf(discoveredRow)),
+        )
+
+        val result = repository.observeAllGourmetsWithDiscovery().first()
+
+        assertEquals(1, result.size)
+        assertEquals(true, result[0].discovered)
+        assertEquals(true, result[0].favorite)
+        assertEquals("name-1", result[0].name)
+    }
+
+    @Test
+    fun observeAllGourmetsWithDiscovery_passesThroughUndiscoveredRow() = runBlocking {
+        val undiscoveredRow = buildRow(gourmetId = 2, discovered = false)
+        val repository = CollectionRepositoryImpl(
+            collectionDao = FakeCollectionDao(rowsToEmit = listOf(undiscoveredRow)),
+        )
+
+        val result = repository.observeAllGourmetsWithDiscovery().first()
+
+        assertEquals(1, result.size)
+        assertEquals(false, result[0].discovered)
+        assertEquals(null, result[0].collectionId)
+        assertEquals(null, result[0].createdAt)
+    }
+
+    @Test
+    fun updateFavorite_delegatesToDaoWithTrue() = runBlocking {
+        val dao = FakeCollectionDao()
+        val repository = CollectionRepositoryImpl(collectionDao = dao)
+
+        repository.updateFavorite(gourmetId = 5, favorite = true)
+
+        assertEquals(5 to true, dao.updateFavoriteCalledWith)
+    }
+
+    @Test
+    fun updateFavorite_delegatesToDaoWithFalse() = runBlocking {
+        val dao = FakeCollectionDao()
+        val repository = CollectionRepositoryImpl(collectionDao = dao)
+
+        repository.updateFavorite(gourmetId = 7, favorite = false)
+
+        assertEquals(7 to false, dao.updateFavoriteCalledWith)
+    }
+
+    private fun buildRow(
+        gourmetId: Int,
+        discovered: Boolean = false,
+        favorite: Boolean = false,
+    ): GourmetWithDiscoveryRow = GourmetWithDiscoveryRow(
+        gourmetId = gourmetId,
+        name = "name-$gourmetId",
+        area = "area-$gourmetId",
+        category = "category-$gourmetId",
+        description = "description-$gourmetId",
+        searchKeyword = "kw-$gourmetId",
+        discovered = discovered,
+        collectionId = if (discovered) gourmetId else null,
+        moodText = if (discovered) "mood-$gourmetId" else null,
+        aiComment = if (discovered) "ai-$gourmetId" else null,
+        favorite = favorite,
+        createdAt = if (discovered) 1_700_000_000_000L else null,
+    )
+
+    private class FakeCollectionDao(
+        private val rowsToEmit: List<GourmetWithDiscoveryRow> = emptyList(),
+    ) : CollectionDao {
+
+        var updateFavoriteCalledWith: Pair<Int, Boolean>? = null
+            private set
+
+        override suspend fun insert(item: GourmetCollectionEntity): Long = 0L
+
+        override fun getAllWithGourmet(): Flow<List<CollectionWithGourmetRow>> = flowOf(emptyList())
+
+        override fun observeAllGourmetsWithDiscovery(): Flow<List<GourmetWithDiscoveryRow>> = flowOf(rowsToEmit)
+
+        override suspend fun getByGourmetId(gourmetId: Int): CollectionWithGourmetRow? = null
+
+        override suspend fun deleteByGourmetId(gourmetId: Int): Int = 0
+
+        override suspend fun updateFavoriteByGourmetId(gourmetId: Int, favorite: Boolean): Int {
+            updateFavoriteCalledWith = gourmetId to favorite
+            return 1
+        }
+
+        override suspend fun existsGourmet(gourmetId: Int): Boolean = false
+    }
+}

--- a/app/src/test/java/com/issy/meshigen/data/repository/HomeRepositoryImplTest.kt
+++ b/app/src/test/java/com/issy/meshigen/data/repository/HomeRepositoryImplTest.kt
@@ -5,8 +5,10 @@ import com.issy.meshigen.data.local.dao.GourmetDao
 import com.issy.meshigen.data.local.entity.GourmetCollectionEntity
 import com.issy.meshigen.data.local.entity.GourmetEntity
 import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -123,11 +125,15 @@ class HomeRepositoryImplTest {
 
         override fun getAllWithGourmet(): Flow<List<CollectionWithGourmetRow>> = emptyFlow()
 
+        override fun observeAllGourmetsWithDiscovery(): Flow<List<GourmetWithDiscoveryRow>> = emptyFlow()
+
         override suspend fun getByGourmetId(gourmetId: Int): CollectionWithGourmetRow? = null
 
         override suspend fun deleteByGourmetId(gourmetId: Int): Int = 0
 
         override suspend fun updateFavoriteByGourmetId(gourmetId: Int, favorite: Boolean): Int = 0
+
+        override suspend fun existsGourmet(gourmetId: Int): Boolean = false
     }
 
     private companion object {

--- a/app/src/test/java/com/issy/meshigen/feature/collection/CollectionListViewModelTest.kt
+++ b/app/src/test/java/com/issy/meshigen/feature/collection/CollectionListViewModelTest.kt
@@ -1,0 +1,156 @@
+package com.issy.meshigen.feature.collection
+
+import com.issy.meshigen.data.local.query.GourmetWithDiscoveryRow
+import com.issy.meshigen.data.repository.CollectionRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CollectionListViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun uiState_initialState_isAllFilterAndAllItems() = runTest {
+        val rows = listOf(
+            buildRow(gourmetId = 1, discovered = true, favorite = true),
+            buildRow(gourmetId = 2, discovered = true, favorite = false),
+            buildRow(gourmetId = 3, discovered = false),
+        )
+        val viewModel = CollectionListViewModel(
+            repository = FakeCollectionRepository(rowsToEmit = rows),
+        )
+
+        val state = viewModel.uiState.first { it.items.isNotEmpty() }
+
+        assertEquals("all", state.selectedFilter)
+        assertEquals(3, state.items.size)
+        assertEquals(2, state.discoveredCount)
+    }
+
+    @Test
+    fun uiState_withUndiscoveredFilter_returnsOnlyUndiscoveredItems() = runTest {
+        val rows = listOf(
+            buildRow(gourmetId = 1, discovered = true),
+            buildRow(gourmetId = 2, discovered = false),
+            buildRow(gourmetId = 3, discovered = false),
+        )
+        val viewModel = CollectionListViewModel(
+            repository = FakeCollectionRepository(rowsToEmit = rows),
+        )
+
+        viewModel.onFilterClick("undiscovered")
+        val state = viewModel.uiState.first { it.selectedFilter == "undiscovered" }
+
+        assertEquals(2, state.items.size)
+        assertEquals(0, state.items.count { it.discovered })
+    }
+
+    @Test
+    fun uiState_withDiscoveredFilter_returnsOnlyDiscoveredItems() = runTest {
+        val rows = listOf(
+            buildRow(1, discovered = true),
+            buildRow(2, discovered = true),
+            buildRow(3, discovered = false),
+        )
+        val viewModel = CollectionListViewModel(
+            repository = FakeCollectionRepository(rowsToEmit = rows),
+        )
+
+        viewModel.onFilterClick("discovered")
+        val state = viewModel.uiState.first { it.selectedFilter == "discovered" }
+
+        assertEquals(2, state.items.size)
+        assertEquals(2, state.items.count { it.discovered })
+    }
+
+    @Test
+    fun uiState_withFavoriteFilter_returnsOnlyDiscoveredAndFavoriteItems() = runTest {
+        val rows = listOf(
+            buildRow(1, discovered = true, favorite = true),
+            buildRow(2, discovered = true, favorite = false),
+            buildRow(3, discovered = false, favorite = true),
+        )
+        val viewModel = CollectionListViewModel(
+            repository = FakeCollectionRepository(rowsToEmit = rows),
+        )
+
+        viewModel.onFilterClick("favorite")
+        val state = viewModel.uiState.first { it.selectedFilter == "favorite" }
+
+        assertEquals(1, state.items.size)
+        assertEquals(true, state.items[0].discovered)
+        assertEquals(true, state.items[0].favorite)
+    }
+
+    @Test
+    fun uiState_discoveredCount_remainsTotalDiscoveredRegardlessOfFilter() = runTest {
+        val rows = listOf(
+            buildRow(1, discovered = true),
+            buildRow(2, discovered = true),
+            buildRow(3, discovered = false),
+        )
+        val viewModel = CollectionListViewModel(
+            repository = FakeCollectionRepository(rowsToEmit = rows),
+        )
+
+        viewModel.onFilterClick("undiscovered")
+        val state = viewModel.uiState.first { it.selectedFilter == "undiscovered" }
+
+        assertEquals(2, state.discoveredCount)
+    }
+
+
+    private fun buildRow(
+        gourmetId: Int,
+        discovered: Boolean = false,
+        favorite: Boolean = false,
+    ): GourmetWithDiscoveryRow = GourmetWithDiscoveryRow(
+        gourmetId = gourmetId,
+        name = "name-$gourmetId",
+        area = "area-$gourmetId",
+        category = "category-$gourmetId",
+        description = "description-$gourmetId",
+        searchKeyword = "kw-$gourmetId",
+        discovered = discovered,
+        collectionId = if (discovered) gourmetId else null,
+        moodText = if (discovered) "mood-$gourmetId" else null,
+        aiComment = if (discovered) "ai-$gourmetId" else null,
+        favorite = favorite,
+        createdAt = if (discovered) 1_700_000_000_000L else null,
+    )
+
+    private class FakeCollectionRepository(
+        private val rowsToEmit: List<GourmetWithDiscoveryRow>,
+    ) : CollectionRepository {
+
+        var updateFavoriteCalledWith: Pair<Int, Boolean>? = null
+            private set
+
+        override fun observeAllGourmetsWithDiscovery() = kotlinx.coroutines.flow.flowOf(rowsToEmit)
+
+        override suspend fun updateFavorite(gourmetId: Int, favorite: Boolean) {
+            updateFavoriteCalledWith = gourmetId to favorite
+        }
+    }
+}

--- a/app/src/test/java/com/issy/meshigen/feature/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/issy/meshigen/feature/detail/DetailViewModelTest.kt
@@ -1,0 +1,119 @@
+package com.issy.meshigen.feature.detail
+
+import com.issy.meshigen.data.local.query.CollectionWithGourmetRow
+import com.issy.meshigen.data.repository.DetailRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetailViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun load_whenIdIsInvalid_stateBecomesNotFound() = runTest {
+        val viewModel = DetailViewModel(repository = FakeDetailRepository())
+
+        viewModel.load(gourmetId = "abc")
+        val state = viewModel.uiState.first { it !is DetailUiState.Loading }
+
+        assertEquals(DetailUiState.NotFound, state)
+    }
+
+    @Test
+    fun load_whenCollectionExists_stateBecomesReady() = runTest {
+        val row = buildRow(gourmetId = 1)
+        val viewModel = DetailViewModel(
+            repository = FakeDetailRepository(rowByGourmetId = mapOf(1 to row)),
+        )
+
+        viewModel.load(gourmetId = "1")
+        val state = viewModel.uiState.first { it !is DetailUiState.Loading }
+
+        assertTrue(state is DetailUiState.Ready)
+        val ready = state as DetailUiState.Ready
+        assertEquals("name-1", ready.item.name)
+        assertEquals("mood-1", ready.item.moodText)
+    }
+
+    @Test
+    fun load_whenCollectionNotExistsButGourmetExists_stateBecomesLocked() = runTest {
+        val viewModel = DetailViewModel(
+            repository = FakeDetailRepository(
+                rowByGourmetId = emptyMap(),
+                existingGourmetIds = setOf(5),
+            ),
+        )
+
+        viewModel.load(gourmetId = "5")
+        val state = viewModel.uiState.first { it !is DetailUiState.Loading }
+
+        assertEquals(DetailUiState.Locked, state)
+    }
+
+    @Test
+    fun load_whenGourmetDoesNotExist_stateBecomesNotFound() = runTest {
+        val viewModel = DetailViewModel(
+            repository = FakeDetailRepository(
+                rowByGourmetId = emptyMap(),
+                existingGourmetIds = emptySet(),
+            ),
+        )
+
+        viewModel.load(gourmetId = "99")
+        val state = viewModel.uiState.first { it !is DetailUiState.Loading }
+
+        assertEquals(DetailUiState.NotFound, state)
+    }
+
+    private fun buildRow(gourmetId: Int): CollectionWithGourmetRow = CollectionWithGourmetRow(
+        collectionId = gourmetId * 100,
+        gourmetId = gourmetId,
+        name = "name-$gourmetId",
+        area = "area-$gourmetId",
+        category = "category-$gourmetId",
+        description = "description-$gourmetId",
+        searchKeyword = "kw-$gourmetId",
+        moodText = "mood-$gourmetId",
+        aiComment = "ai-$gourmetId",
+        favorite = false,
+        createdAt = 1_700_000_000_000L,
+    )
+
+    private class FakeDetailRepository(
+        private val rowByGourmetId: Map<Int, CollectionWithGourmetRow> = emptyMap(),
+        private val existingGourmetIds: Set<Int> = emptySet(),
+    ) : DetailRepository {
+
+        override suspend fun getByGourmetId(gourmetId: Int): CollectionWithGourmetRow? =
+            rowByGourmetId[gourmetId]
+
+        override suspend fun updateFavoriteByGourmetId(gourmetId: Int, favorite: Boolean): Boolean
+                = true
+
+        override suspend fun deleteByGourmetId(gourmetId: Int): Boolean = true
+
+        override suspend fun existsGourmet(gourmetId: Int): Boolean =
+            gourmetId in existingGourmetIds
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ composeBom = "2026.03.01"
 navigationCompose = "2.9.7"
 room = "2.8.4"
 ksp = "2.3.6"
+kotlinxCoroutinesTest = "1.10.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -33,6 +34,7 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- データ層・ViewModel・詳細状態の Unit Test を追加し、発見型図鑑の主要仕様の回帰を担保
- 図鑑 Preview に未発見/発見済み/ロック詳細を追加し、仕様 v1.5.0 の見た目を可視化
- 既存 FakeCollectionDao の interface 同期不足を解消

Closes #61

## Changes
- `CollectionRepositoryImplTest`: 30件透過/発見判定/お気に入り委譲を検証 (5 tests)
- `CollectionListViewModelTest`: 4フィルタ + discoveredCount 集計の独立性を検証 (5 tests)
- `DetailViewModelTest`: load の Loading/Ready/Locked/NotFound 遷移を検証 (4 tests)
- `DetailScreenPreview`: Locked / Locked Dark / NotFound / Loading を追加
- `CollectionListScreenPreview`: すべて未発見 / すべて発見済み を追加
- `kotlinx-coroutines-test 1.10.2` 導入（viewModelScope テストの Dispatchers.Main 問題に対応）

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` 成功（20 tests, 0 failures）
- [x] `./gradlew :app:compileDebugKotlin` 成功
- [x] 手動E2E: Home→自動登録→一覧→詳細 の導線が壊れていないこと
- [x] 手動E2E: 未発見カードをタップして Locked 詳細が表示されること