### PR TITLE
feat: [#82] プロンプトビルダーとresponseSchemaを実装する

### DIFF
--- a/app/src/main/java/com/issy/meshigen/data/ai/AiPromptBuilder.kt
+++ b/app/src/main/java/com/issy/meshigen/data/ai/AiPromptBuilder.kt
@@ -1,0 +1,28 @@
+package com.issy.meshigen.data.ai
+
+import com.issy.meshigen.data.local.entity.GourmetEntity
+
+internal object AiPromptBuilder {
+
+    const val SYSTEM_INSTRUCTION =
+        "候補リストにあるグルメだけから選び、必ずidで返してください。リストにないグルメを創作しないでください。"
+
+    private val PROMPT_TEMPLATE = """
+        あなたは北九州のB級グルメに詳しい案内人です。
+
+        以下のグルメリスト（id|name|area|category|description）の中から、
+        ユーザーの気分に合うものを1〜3件選んでください。
+        返却順は、ユーザーの気分との適合度が高い順にしてください。
+
+        ## グルメリスト
+        {軽量フォーマットで全候補を挿入}
+
+        ## ユーザーの気分
+        {ユーザーの入力テキスト}
+    """.trimIndent()
+
+    fun build(moodText: String, gourmets: List<GourmetEntity>): String =
+        PROMPT_TEMPLATE
+            .replace("{軽量フォーマットで全候補を挿入}", GourmetPromptFormatter.toLightweightList(gourmets))
+            .replace("{ユーザーの入力テキスト}", moodText)
+}

--- a/app/src/main/java/com/issy/meshigen/data/ai/AiResponseSchema.kt
+++ b/app/src/main/java/com/issy/meshigen/data/ai/AiResponseSchema.kt
@@ -1,0 +1,18 @@
+package com.issy.meshigen.data.ai
+
+import com.google.firebase.ai.type.Schema
+
+internal object AiResponseSchema {
+    val selectedSchema: Schema = Schema.obj(
+        mapOf(
+            "selected" to Schema.array(
+                Schema.obj(
+                    mapOf(
+                        "id" to Schema.integer(),
+                        "reason" to Schema.string()
+                    )
+                )
+            )
+        )
+    )
+}

--- a/app/src/main/java/com/issy/meshigen/data/ai/GourmetPromptFormatter.kt
+++ b/app/src/main/java/com/issy/meshigen/data/ai/GourmetPromptFormatter.kt
@@ -1,0 +1,21 @@
+package com.issy.meshigen.data.ai
+
+import com.issy.meshigen.data.local.entity.GourmetEntity
+
+internal object GourmetPromptFormatter {
+
+    fun toLightweightLine(gourmet: GourmetEntity): String {
+        val id = "${gourmet.id}"
+        val name = sanitize(gourmet.name)
+        val area = sanitize(gourmet.area)
+        val category = sanitize(gourmet.category)
+        val description = sanitize(gourmet.description)
+        return "$id|$name|$area|$category|$description"
+    }
+
+    fun toLightweightList(gourmets: List<GourmetEntity>): String =
+        gourmets.joinToString(separator = "\n") { toLightweightLine(it) }
+
+    private fun sanitize(value: String): String =
+        value.replace("|", " ").replace("\n", " ")
+}

--- a/app/src/test/java/com/issy/meshigen/data/ai/AiPromptBuilderTest.kt
+++ b/app/src/test/java/com/issy/meshigen/data/ai/AiPromptBuilderTest.kt
@@ -1,0 +1,56 @@
+package com.issy.meshigen.data.ai
+
+import com.issy.meshigen.data.local.entity.GourmetEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AiPromptBuilderTest {
+
+    @Test
+    fun build_singleGourmet_returnsExpectedPrompt() {
+        val gourmet = gourmetWith(id = 1, name = "焼うどん", area = "小倉北区・鳥町", category = "麺類", description = "小倉発祥")
+        val moodText = "さっぱりしたものが食べたい"
+
+        val result = AiPromptBuilder.build(moodText, listOf(gourmet))
+
+        val expected = """
+            あなたは北九州のB級グルメに詳しい案内人です。
+
+            以下のグルメリスト（id|name|area|category|description）の中から、
+            ユーザーの気分に合うものを1〜3件選んでください。
+            返却順は、ユーザーの気分との適合度が高い順にしてください。
+
+            ## グルメリスト
+            1|焼うどん|小倉北区・鳥町|麺類|小倉発祥
+
+            ## ユーザーの気分
+            さっぱりしたものが食べたい
+        """.trimIndent()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun build_emptyMoodText_stillBuildsValidPrompt() {
+        val gourmet = gourmetWith(id = 1, name = "焼うどん", area = "小倉北区", category = "麺類", description = "説明")
+
+        val result = AiPromptBuilder.build("", listOf(gourmet))
+
+        assertTrue(result.contains("## ユーザーの気分\n"))
+    }
+
+    private fun gourmetWith(
+        id: Int,
+        name: String,
+        area: String,
+        category: String,
+        description: String,
+    ) = GourmetEntity(
+        id = id,
+        name = name,
+        area = area,
+        category = category,
+        description = description,
+        searchKeyword = "",
+    )
+}

--- a/app/src/test/java/com/issy/meshigen/data/ai/GourmetPromptFormatterTest.kt
+++ b/app/src/test/java/com/issy/meshigen/data/ai/GourmetPromptFormatterTest.kt
@@ -1,0 +1,60 @@
+package com.issy.meshigen.data.ai
+
+import com.issy.meshigen.data.local.entity.GourmetEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GourmetPromptFormatterTest {
+
+    @Test
+    fun toLightweightLine_singleGourmet_returnsExpectedFormat() {
+        val gourmet = gourmetWith(id = 1, name = "焼うどん", area = "小倉北区・鳥町", category = "麺類", description = "小倉発祥のB級グルメ")
+        val result = GourmetPromptFormatter.toLightweightLine(gourmet)
+        assertEquals("1|焼うどん|小倉北区・鳥町|麺類|小倉発祥のB級グルメ", result)
+    }
+
+    @Test
+    fun toLightweightList_multipleGourmets_returnsNewlineSeparated() {
+        val gourmets = listOf(
+            gourmetWith(id = 1, name = "焼うどん", area = "小倉北区", category = "麺類", description = "desc1"),
+            gourmetWith(id = 2, name = "焼きカレー", area = "門司区", category = "カレー", description = "desc2"),
+        )
+        val result = GourmetPromptFormatter.toLightweightList(gourmets)
+        assertEquals("1|焼うどん|小倉北区|麺類|desc1\n2|焼きカレー|門司区|カレー|desc2", result)
+    }
+
+    @Test
+    fun toLightweightLine_pipeInName_replacedWithSpace() {
+        val gourmet = gourmetWith(id = 3, name = "焼|うどん", area = "小倉北区", category = "麺類", description = "説明")
+        val result = GourmetPromptFormatter.toLightweightLine(gourmet)
+        assertEquals("3|焼 うどん|小倉北区|麺類|説明", result)
+    }
+
+    @Test
+    fun toLightweightLine_newlineInDescription_replacedWithSpace() {
+        val gourmet = gourmetWith(id = 4, name = "焼うどん", area = "小倉北区", category = "麺類", description = "説明\n補足")
+        val result = GourmetPromptFormatter.toLightweightLine(gourmet)
+        assertEquals("4|焼うどん|小倉北区|麺類|説明 補足", result)
+    }
+
+    @Test
+    fun toLightweightList_emptyList_returnsEmptyString() {
+        val result = GourmetPromptFormatter.toLightweightList(emptyList())
+        assertEquals("", result)
+    }
+
+    private fun gourmetWith(
+        id: Int,
+        name: String,
+        area: String,
+        category: String,
+        description: String,
+    ) = GourmetEntity(
+        id = id,
+        name = name,
+        area = area,
+        category = category,
+        description = description,
+        searchKeyword = "",
+    )
+}


### PR DESCRIPTION
## Summary
- `GourmetPromptFormatter` — グルメリストを `id|name|area|category|description` の軽量1行フォーマットに変換（`|`・`\n` 混入を空白置換）
- `AiPromptBuilder` — SPEC §AIプロンプト設計の文面を完全再現するテンプレート展開。`SYSTEM_INSTRUCTION` 定数を併設
- `AiResponseSchema` — `selected: [{id, reason}]` 形の Firebase AI Logic SDK スキーマを定義
- ユニットテスト2本（区切り破壊なし・SPEC文面完全一致を保証）

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` が成功する
- [x] `./gradlew :app:testDebugUnitTest --tests "com.issy.meshigen.data.ai.*"` が成功する（7テスト全パス）

## Closes
Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HRaF91bmxnCayufrDurY1